### PR TITLE
[Feat] #15 - 서브약 추가 뷰 추가

### DIFF
--- a/APillLog/APillLog.xcodeproj/project.pbxproj
+++ b/APillLog/APillLog.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		34982C602885420F003BBBD4 /* AddSecondaryPillView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34982C5F2885420F003BBBD4 /* AddSecondaryPillView.storyboard */; };
+		34982C6228854424003BBBD4 /* AddSecondaryPillViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34982C6128854424003BBBD4 /* AddSecondaryPillViewController.swift */; };
 		876ED1A02882A33B00179767 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876ED19F2882A33B00179767 /* AppDelegate.swift */; };
 		876ED1A22882A33B00179767 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876ED1A12882A33B00179767 /* SceneDelegate.swift */; };
 		876ED1A72882A33B00179767 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 876ED1A52882A33B00179767 /* Main.storyboard */; };
@@ -37,6 +39,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		34982C5F2885420F003BBBD4 /* AddSecondaryPillView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AddSecondaryPillView.storyboard; sourceTree = "<group>"; };
+		34982C6128854424003BBBD4 /* AddSecondaryPillViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSecondaryPillViewController.swift; sourceTree = "<group>"; };
 		876ED19C2882A33B00179767 /* APillLog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = APillLog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		876ED19F2882A33B00179767 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		876ED1A12882A33B00179767 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -79,6 +83,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		34982C5E2885415E003BBBD4 /* SecondaryPill */ = {
+			isa = PBXGroup;
+			children = (
+				34982C5F2885420F003BBBD4 /* AddSecondaryPillView.storyboard */,
+				34982C6128854424003BBBD4 /* AddSecondaryPillViewController.swift */,
+			);
+			path = SecondaryPill;
+			sourceTree = "<group>";
+		};
 		876ED1932882A33B00179767 = {
 			isa = PBXGroup;
 			children = (
@@ -204,6 +217,7 @@
 		A8F4F2C2288478010008EB48 /* MedicationTab */ = {
 			isa = PBXGroup;
 			children = (
+				34982C5E2885415E003BBBD4 /* SecondaryPill */,
 				A8F4F2C328847A010008EB48 /* MedicationView.storyboard */,
 				A8F4F2CA28847A380008EB48 /* MedicationViewController.swift */,
 			);
@@ -271,6 +285,7 @@
 				A8F4F2B7288477390008EB48 /* AppleSDGothicNeoUL.ttf in Resources */,
 				A8F4F2C928847A270008EB48 /* HistoryView.storyboard in Resources */,
 				A8F4F2B8288477390008EB48 /* AppleSDGothicNeoM.ttf in Resources */,
+				34982C602885420F003BBBD4 /* AddSecondaryPillView.storyboard in Resources */,
 				A8F4F2B6288477390008EB48 /* AppleSDGothicNeoT.ttf in Resources */,
 				A8F4F2C628847A0A0008EB48 /* DiaryView.storyboard in Resources */,
 				A8F4F2C428847A010008EB48 /* MedicationView.storyboard in Resources */,
@@ -302,6 +317,7 @@
 				9A273BFC2883ED1B0006427B /* Condition+CoreDataProperties.swift in Sources */,
 				9A273BFB2883ED1B0006427B /* Condition+CoreDataClass.swift in Sources */,
 				876ED1AA2882A33B00179767 /* APillLog.xcdatamodeld in Sources */,
+				34982C6228854424003BBBD4 /* AddSecondaryPillViewController.swift in Sources */,
 				A8F4F2CB28847A380008EB48 /* MedicationViewController.swift in Sources */,
 				876ED1A02882A33B00179767 /* AppDelegate.swift in Sources */,
 				876ED1A22882A33B00179767 /* SceneDelegate.swift in Sources */,

--- a/APillLog/APillLog/View/Base.lproj/Main.storyboard
+++ b/APillLog/APillLog/View/Base.lproj/Main.storyboard
@@ -11,7 +11,6 @@
         <!--Tab Bar Controller-->
         <scene sceneID="40l-E8-9PQ">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Dgy-EL-fwu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tabBarController id="BCn-ad-AhM" sceneMemberID="viewController">
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="nlc-vO-Um5">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="49"/>
@@ -25,19 +24,20 @@
                         <segue destination="WoF-8C-tyc" kind="relationship" relationship="viewControllers" id="37R-k2-5VH"/>
                     </connections>
                 </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Dgy-EL-fwu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-136" y="95"/>
         </scene>
         <!--MedicationViewController-->
         <scene sceneID="i3p-xV-K4f">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="GH8-Pv-1hO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <viewControllerPlaceholder storyboardName="MedicationView" referencedIdentifier="MedicationViewController" id="Dhf-Tm-d6G" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="cM7-yL-Li5">
                         <imageReference key="image" image="pills.fill" catalog="system" symbolScale="default"/>
                         <imageReference key="selectedImage" image="pills" catalog="system" symbolScale="default"/>
                     </tabBarItem>
                 </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GH8-Pv-1hO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="667" y="-10"/>
         </scene>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="en2-nt-aBt">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
@@ -14,21 +14,31 @@
             <objects>
                 <viewController storyboardIdentifier="MedicationViewController" id="en2-nt-aBt" customClass="MedicationViewController" customModule="APillLog" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="NaL-pe-2VR">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Medication View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xDP-jb-QlZ">
-                                <rect key="frame" x="144" y="437.5" width="126" height="21"/>
+                                <rect key="frame" x="132" y="411.66666666666669" width="126" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EM6-9f-GMI">
+                                <rect key="frame" x="138.66666666666666" y="530" width="113" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="서브약 추가하기"/>
+                                <connections>
+                                    <segue destination="Y7F-Vm-JMY" kind="presentation" id="mj8-zQ-7JE"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="MND-81-mzl"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="xDP-jb-QlZ" firstAttribute="centerY" secondItem="NaL-pe-2VR" secondAttribute="centerY" id="M2f-N4-PHg"/>
+                            <constraint firstItem="MND-81-mzl" firstAttribute="bottom" secondItem="EM6-9f-GMI" secondAttribute="bottom" constant="200" id="NiX-WB-wqJ"/>
                             <constraint firstItem="xDP-jb-QlZ" firstAttribute="centerX" secondItem="NaL-pe-2VR" secondAttribute="centerX" id="OeL-u0-H5k"/>
+                            <constraint firstItem="EM6-9f-GMI" firstAttribute="centerX" secondItem="NaL-pe-2VR" secondAttribute="centerX" id="rbc-tI-rXt"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="복용기록" id="rpt-Ea-0JZ">
@@ -41,6 +51,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HeD-UO-cz2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="118.84057971014494" y="91.741071428571431"/>
+        </scene>
+        <!--AddSecondPillStoryboard-->
+        <scene sceneID="mvT-Rz-aVm">
+            <objects>
+                <viewControllerPlaceholder storyboardName="AddSecondaryPillView" referencedIdentifier="AddSecondPillStoryboard" id="Y7F-Vm-JMY" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ltf-YT-dqi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="807" y="92"/>
         </scene>
     </scenes>
     <resources>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="en2-nt-aBt">
-    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
@@ -14,26 +14,11 @@
             <objects>
                 <viewController storyboardIdentifier="MedicationViewController" id="en2-nt-aBt" customClass="MedicationViewController" customModule="APillLog" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="NaL-pe-2VR">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Medication View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xDP-jb-QlZ">
-                                <rect key="frame" x="132" y="411.66666666666669" width="126" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EM6-9f-GMI">
-                                <rect key="frame" x="138.66666666666666" y="530" width="113" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="서브약 추가하기"/>
-                                <connections>
-                                    <action selector="tapAddSecondaryPillButton" destination="en2-nt-aBt" eventType="touchUpInside" id="1X1-Ms-S2A"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kXC-e4-sFB">
-                                <rect key="frame" x="102" y="501" width="187" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="124.5" y="323" width="126" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -43,9 +28,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="xDP-jb-QlZ" firstAttribute="centerY" secondItem="NaL-pe-2VR" secondAttribute="centerY" id="M2f-N4-PHg"/>
-                            <constraint firstItem="MND-81-mzl" firstAttribute="bottom" secondItem="EM6-9f-GMI" secondAttribute="bottom" constant="200" id="NiX-WB-wqJ"/>
                             <constraint firstItem="xDP-jb-QlZ" firstAttribute="centerX" secondItem="NaL-pe-2VR" secondAttribute="centerX" id="OeL-u0-H5k"/>
-                            <constraint firstItem="EM6-9f-GMI" firstAttribute="centerX" secondItem="NaL-pe-2VR" secondAttribute="centerX" id="rbc-tI-rXt"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="복용기록" id="rpt-Ea-0JZ">
@@ -54,13 +37,10 @@
                         <imageReference key="selectedImage" image="pills.fill" catalog="system" symbolScale="default"/>
                     </tabBarItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <connections>
-                        <outlet property="addedSecondaryPillName" destination="kXC-e4-sFB" id="yPt-cs-vBG"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HeD-UO-cz2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="118.46153846153845" y="91.706161137440759"/>
+            <point key="canvasLocation" x="117.59999999999999" y="91.304347826086968"/>
         </scene>
     </scenes>
     <resources>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="en2-nt-aBt">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Image references" minToolsVersion="12.0"/>
@@ -14,11 +14,11 @@
             <objects>
                 <viewController storyboardIdentifier="MedicationViewController" id="en2-nt-aBt" customClass="MedicationViewController" customModule="APillLog" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="NaL-pe-2VR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Medication View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xDP-jb-QlZ">
-                                <rect key="frame" x="124.5" y="323" width="126" height="21"/>
+                                <rect key="frame" x="132" y="411.66666666666669" width="126" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -28,7 +28,7 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="서브약 추가하기"/>
                                 <connections>
-                                    <segue destination="Y7F-Vm-JMY" kind="presentation" id="mj8-zQ-7JE"/>
+                                    <segue destination="42q-1c-hZ5" kind="presentation" id="LUo-MQ-Brd"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -53,12 +53,12 @@
             <point key="canvasLocation" x="118.84057971014494" y="91.741071428571431"/>
         </scene>
         <!--AddSecondPillStoryboard-->
-        <scene sceneID="mvT-Rz-aVm">
+        <scene sceneID="qbY-UZ-bg0">
             <objects>
-                <viewControllerPlaceholder storyboardName="AddSecondaryPillView" referencedIdentifier="AddSecondPillStoryboard" id="Y7F-Vm-JMY" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Ltf-YT-dqi" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <viewControllerPlaceholder storyboardName="AddSecondaryPillView" referencedIdentifier="AddSecondPillStoryboard" id="42q-1c-hZ5" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bT2-DY-t52" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="807" y="92"/>
+            <point key="canvasLocation" x="909" y="92"/>
         </scene>
     </scenes>
     <resources>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -28,9 +28,16 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="서브약 추가하기"/>
                                 <connections>
-                                    <segue destination="42q-1c-hZ5" kind="presentation" id="LUo-MQ-Brd"/>
+                                    <action selector="tapAddSecondaryPillButton" destination="en2-nt-aBt" eventType="touchUpInside" id="1X1-Ms-S2A"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kXC-e4-sFB">
+                                <rect key="frame" x="102" y="501" width="187" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="MND-81-mzl"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -47,18 +54,13 @@
                         <imageReference key="selectedImage" image="pills.fill" catalog="system" symbolScale="default"/>
                     </tabBarItem>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="addedSecondaryPillName" destination="kXC-e4-sFB" id="yPt-cs-vBG"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HeD-UO-cz2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="118.84057971014494" y="91.741071428571431"/>
-        </scene>
-        <!--AddSecondPillStoryboard-->
-        <scene sceneID="qbY-UZ-bg0">
-            <objects>
-                <viewControllerPlaceholder storyboardName="AddSecondaryPillView" referencedIdentifier="AddSecondPillStoryboard" id="42q-1c-hZ5" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="bT2-DY-t52" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="909" y="92"/>
+            <point key="canvasLocation" x="118.46153846153845" y="91.706161137440759"/>
         </scene>
     </scenes>
     <resources>

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -8,22 +8,11 @@
 import UIKit
 
 class MedicationViewController: UIViewController {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -7,7 +7,9 @@
 
 import UIKit
 
-class MedicationViewController: UIViewController {
+class MedicationViewController: UIViewController, AddSecondaryPillViewControllerDelegate {
+
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,4 +17,19 @@ class MedicationViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
+    @IBOutlet var addedSecondaryPillName: UILabel!
+    
+    @IBAction func tapAddSecondaryPillButton() {
+        let storyboard: UIStoryboard = UIStoryboard(name: "AddSecondaryPillView", bundle: nil)
+        let nextViewController = storyboard.instantiateViewController(withIdentifier: "AddSecondPillStoryboard") as! AddSecondaryPillViewController
+        
+        nextViewController.delegate = self
+        
+        self.present(nextViewController, animated: true)
+    }
+    
+    // MARK: AddSecondaryPillViewControllerDelegate
+    func modalDidFinished(selectedPill: String) {
+        addedSecondaryPillName.text = selectedPill
+    }
 }

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -17,7 +17,6 @@ class MedicationViewController: UIViewController, AddSecondaryPillViewController
         // Do any additional setup after loading the view.
     }
     
-    @IBOutlet var addedSecondaryPillName: UILabel!
     
     @IBAction func tapAddSecondaryPillButton() {
         let storyboard: UIStoryboard = UIStoryboard(name: "AddSecondaryPillView", bundle: nil)
@@ -28,8 +27,10 @@ class MedicationViewController: UIViewController, AddSecondaryPillViewController
         self.present(nextViewController, animated: true)
     }
     
+    
     // MARK: AddSecondaryPillViewControllerDelegate
     func modalDidFinished(selectedPill: String) {
-        addedSecondaryPillName.text = selectedPill
+        // TODO : 아래에 추가약 복용 추가하기 모달이 내려간 이후 수행할 함수 작성
+        
     }
 }

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -29,7 +29,7 @@ class MedicationViewController: UIViewController, AddSecondaryPillViewController
     
     
     // MARK: AddSecondaryPillViewControllerDelegate
-    func modalDidFinished(selectedPill: String) {
+    func didFinishModal(selectedPill: String) {
         // TODO : 아래에 추가약 복용 추가하기 모달이 내려간 이후 수행할 함수 작성
         
     }

--- a/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillView.storyboard
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="v62-c9-Gww">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Add Secondary Pill View Controller-->
+        <scene sceneID="5Ly-37-buI">
+            <objects>
+                <viewController storyboardIdentifier="AddSecondPillStoryboard" id="v62-c9-Gww" customClass="AddSecondaryPillViewController" customModule="APillLog" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="BMH-hQ-7SN">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추가로 먹은 약을 입력하세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MX1-lp-6X6">
+                                <rect key="frame" x="25" y="75" width="364" height="24"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <searchBar contentMode="redraw" searchBarStyle="minimal" text="" placeholder="약 이름을 검색하세요" translatesAutoresizingMaskIntoConstraints="NO" id="cS4-BM-5jE">
+                                <rect key="frame" x="25" y="115" width="364" height="51"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="LCc-0b-GqK">
+                                <rect key="frame" x="25" y="166" width="364" height="705"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SecondaryPillCell" rowHeight="60" id="mXK-JT-OpP">
+                                        <rect key="frame" x="0.0" y="44.5" width="364" height="60"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mXK-JT-OpP" id="9F1-gx-IM0">
+                                            <rect key="frame" x="0.0" y="0.0" width="364" height="60"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sZc-uH-cYW">
+                                                    <rect key="frame" x="20" y="11" width="324" height="38"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="sZc-uH-cYW" firstAttribute="leading" secondItem="9F1-gx-IM0" secondAttribute="leadingMargin" id="6Dt-mu-QVU"/>
+                                                <constraint firstItem="sZc-uH-cYW" firstAttribute="top" secondItem="9F1-gx-IM0" secondAttribute="topMargin" id="E8g-KQ-8pG"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="sZc-uH-cYW" secondAttribute="bottom" id="cId-Mn-Bs2"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="sZc-uH-cYW" secondAttribute="trailing" id="xgI-ka-h4Y"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CjD-Xr-wH6">
+                                <rect key="frame" x="25" y="25" width="80" height="34"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="80" id="TmT-2G-lrn"/>
+                                </constraints>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="취소">
+                                    <color key="titleColor" name="AccentColor"/>
+                                </state>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ZdG-yb-knB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="cS4-BM-5jE" firstAttribute="leading" secondItem="MX1-lp-6X6" secondAttribute="leading" id="1hp-Ub-RKM"/>
+                            <constraint firstItem="LCc-0b-GqK" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="5P7-kb-bbj"/>
+                            <constraint firstItem="MX1-lp-6X6" firstAttribute="top" secondItem="CjD-Xr-wH6" secondAttribute="bottom" constant="16" id="7vw-Yd-vuy"/>
+                            <constraint firstAttribute="bottom" secondItem="LCc-0b-GqK" secondAttribute="bottom" constant="25" id="8Aw-xI-6IX"/>
+                            <constraint firstItem="cS4-BM-5jE" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="QZb-aO-q7h"/>
+                            <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="MX1-lp-6X6" secondAttribute="trailing" constant="25" id="Qj7-9E-inf"/>
+                            <constraint firstItem="cS4-BM-5jE" firstAttribute="leading" secondItem="LCc-0b-GqK" secondAttribute="leading" id="RAg-KJ-jJQ"/>
+                            <constraint firstItem="CjD-Xr-wH6" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="Xsb-JS-D9D"/>
+                            <constraint firstItem="LCc-0b-GqK" firstAttribute="top" secondItem="cS4-BM-5jE" secondAttribute="bottom" id="dil-4T-pRA"/>
+                            <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="LCc-0b-GqK" secondAttribute="trailing" constant="25" id="doZ-Yu-5gu"/>
+                            <constraint firstItem="MX1-lp-6X6" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="ehm-NY-YTS"/>
+                            <constraint firstItem="cS4-BM-5jE" firstAttribute="trailing" secondItem="LCc-0b-GqK" secondAttribute="trailing" id="jgf-QQ-eO0"/>
+                            <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="cS4-BM-5jE" secondAttribute="trailing" constant="25" id="jrW-GH-f1U"/>
+                            <constraint firstItem="cS4-BM-5jE" firstAttribute="top" secondItem="MX1-lp-6X6" secondAttribute="bottom" constant="16" id="xAn-8z-RSE"/>
+                            <constraint firstItem="CjD-Xr-wH6" firstAttribute="top" secondItem="BMH-hQ-7SN" secondAttribute="top" constant="25" id="zr0-rN-sOX"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mkS-B0-004" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="842" y="98"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="AccentColor">
+            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillView.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="v62-c9-Gww">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
@@ -14,48 +14,58 @@
             <objects>
                 <viewController storyboardIdentifier="AddSecondPillStoryboard" id="v62-c9-Gww" customClass="AddSecondaryPillViewController" customModule="APillLog" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BMH-hQ-7SN">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추가로 먹은 약을 입력하세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MX1-lp-6X6">
-                                <rect key="frame" x="25" y="75" width="364" height="24"/>
+                                <rect key="frame" x="25" y="75" width="340" height="24"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" text="" placeholder="약 이름을 검색하세요" translatesAutoresizingMaskIntoConstraints="NO" id="cS4-BM-5jE">
-                                <rect key="frame" x="25" y="115" width="364" height="51"/>
+                                <rect key="frame" x="25" y="115" width="340" height="51"/>
                                 <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <outlet property="delegate" destination="v62-c9-Gww" id="epM-cL-34X"/>
+                                </connections>
                             </searchBar>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="LCc-0b-GqK">
-                                <rect key="frame" x="25" y="166" width="364" height="705"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="LCc-0b-GqK">
+                                <rect key="frame" x="25" y="210" width="340" height="609"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SecondaryPillCell" rowHeight="60" id="mXK-JT-OpP">
-                                        <rect key="frame" x="0.0" y="44.5" width="364" height="60"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SecondaryPillTableViewCell" rowHeight="60" id="mXK-JT-OpP" customClass="SecondaryPillTableViewCell" customModule="APillLog" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="340" height="60"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mXK-JT-OpP" id="9F1-gx-IM0">
-                                            <rect key="frame" x="0.0" y="0.0" width="364" height="60"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="340" height="60"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sZc-uH-cYW">
-                                                    <rect key="frame" x="20" y="11" width="324" height="38"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sZc-uH-cYW" customClass="S">
+                                                    <rect key="frame" x="10" y="11" width="320" height="38"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="sZc-uH-cYW" firstAttribute="leading" secondItem="9F1-gx-IM0" secondAttribute="leadingMargin" id="6Dt-mu-QVU"/>
+                                                <constraint firstItem="sZc-uH-cYW" firstAttribute="leading" secondItem="9F1-gx-IM0" secondAttribute="leadingMargin" constant="-10" id="6Dt-mu-QVU"/>
                                                 <constraint firstItem="sZc-uH-cYW" firstAttribute="top" secondItem="9F1-gx-IM0" secondAttribute="topMargin" id="E8g-KQ-8pG"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="sZc-uH-cYW" secondAttribute="bottom" id="cId-Mn-Bs2"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="sZc-uH-cYW" secondAttribute="trailing" id="xgI-ka-h4Y"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="sZc-uH-cYW" secondAttribute="trailing" constant="-10" id="xgI-ka-h4Y"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="pillNameView" destination="sZc-uH-cYW" id="Q8z-c0-kfL"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="v62-c9-Gww" id="p8y-UK-TVH"/>
+                                    <outlet property="delegate" destination="v62-c9-Gww" id="Uyh-bP-dcl"/>
+                                </connections>
                             </tableView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CjD-Xr-wH6">
+                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CjD-Xr-wH6">
                                 <rect key="frame" x="25" y="25" width="80" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="TmT-2G-lrn"/>
@@ -64,38 +74,115 @@
                                 <state key="normal" title="취소">
                                     <color key="titleColor" name="AccentColor"/>
                                 </state>
+                                <connections>
+                                    <action selector="tapCancleButton" destination="v62-c9-Gww" eventType="touchUpInside" id="J44-Zc-iBP"/>
+                                </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fhx-PY-MvB">
+                                <rect key="frame" x="255" y="168" width="110" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="110" id="R6t-LD-bjL"/>
+                                    <constraint firstAttribute="height" constant="40" id="owf-hS-bJd"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" cornerStyle="capsule">
+                                    <backgroundConfiguration key="background">
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="strokeColor" red="0.56078431370000004" green="0.56078431370000004" blue="0.56078431370000004" alpha="1" colorSpace="calibratedRGB"/>
+                                    </backgroundConfiguration>
+                                    <attributedString key="attributedTitle">
+                                        <fragment content="약 추가하기">
+                                            <attributes>
+                                                <font key="NSFont" size="16" name="AppleSDGothicNeo-Regular"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                    <color key="baseForegroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="tapAddPillButton" destination="v62-c9-Gww" eventType="touchUpInside" id="e6g-7F-OVQ"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vse-Uz-01e">
+                                <rect key="frame" x="26" y="178" width="9" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="9" id="YTF-Oh-liZ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Qw0-EW-Gqe">
+                                <rect key="frame" x="35" y="166" width="220" height="44"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="없는 약 추가하기" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XKP-ZM-ucC">
+                                        <rect key="frame" x="0.0" y="0.0" width="220" height="43.666666666666664"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V1x-ts-bDs" userLabel="seperator">
+                                        <rect key="frame" x="0.0" y="43.666666666666657" width="220" height="0.3333333333333357"/>
+                                        <color key="backgroundColor" systemColor="separatorColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="0.5" id="e6r-4a-CGb"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="V1x-ts-bDs" firstAttribute="top" secondItem="XKP-ZM-ucC" secondAttribute="bottom" id="tlL-WD-W1z"/>
+                                    <constraint firstAttribute="bottom" secondItem="V1x-ts-bDs" secondAttribute="bottom" id="zpX-gY-hhM"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ZdG-yb-knB"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="Qw0-EW-Gqe" firstAttribute="leading" secondItem="Vse-Uz-01e" secondAttribute="trailing" id="18R-Hv-tAr"/>
                             <constraint firstItem="cS4-BM-5jE" firstAttribute="leading" secondItem="MX1-lp-6X6" secondAttribute="leading" id="1hp-Ub-RKM"/>
                             <constraint firstItem="LCc-0b-GqK" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="5P7-kb-bbj"/>
                             <constraint firstItem="MX1-lp-6X6" firstAttribute="top" secondItem="CjD-Xr-wH6" secondAttribute="bottom" constant="16" id="7vw-Yd-vuy"/>
                             <constraint firstAttribute="bottom" secondItem="LCc-0b-GqK" secondAttribute="bottom" constant="25" id="8Aw-xI-6IX"/>
+                            <constraint firstItem="fhx-PY-MvB" firstAttribute="top" secondItem="cS4-BM-5jE" secondAttribute="bottom" constant="2" id="9IP-J5-BS8"/>
+                            <constraint firstItem="LCc-0b-GqK" firstAttribute="top" secondItem="Qw0-EW-Gqe" secondAttribute="bottom" id="C4k-IW-IRj"/>
+                            <constraint firstItem="LCc-0b-GqK" firstAttribute="top" secondItem="fhx-PY-MvB" secondAttribute="bottom" constant="2" id="OlI-CJ-tKa"/>
                             <constraint firstItem="cS4-BM-5jE" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="QZb-aO-q7h"/>
                             <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="MX1-lp-6X6" secondAttribute="trailing" constant="25" id="Qj7-9E-inf"/>
                             <constraint firstItem="cS4-BM-5jE" firstAttribute="leading" secondItem="LCc-0b-GqK" secondAttribute="leading" id="RAg-KJ-jJQ"/>
+                            <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="LCc-0b-GqK" secondAttribute="trailing" constant="25" id="US6-Az-gzK"/>
+                            <constraint firstItem="LCc-0b-GqK" firstAttribute="top" secondItem="Vse-Uz-01e" secondAttribute="bottom" constant="11" id="VBo-yA-EZC"/>
+                            <constraint firstItem="Qw0-EW-Gqe" firstAttribute="top" secondItem="cS4-BM-5jE" secondAttribute="bottom" id="WHi-7b-9a2"/>
                             <constraint firstItem="CjD-Xr-wH6" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="Xsb-JS-D9D"/>
-                            <constraint firstItem="LCc-0b-GqK" firstAttribute="top" secondItem="cS4-BM-5jE" secondAttribute="bottom" id="dil-4T-pRA"/>
+                            <constraint firstItem="Vse-Uz-01e" firstAttribute="top" secondItem="BMH-hQ-7SN" secondAttribute="top" constant="178" id="YLQ-HS-jee"/>
                             <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="LCc-0b-GqK" secondAttribute="trailing" constant="25" id="doZ-Yu-5gu"/>
                             <constraint firstItem="MX1-lp-6X6" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="25" id="ehm-NY-YTS"/>
+                            <constraint firstItem="fhx-PY-MvB" firstAttribute="leading" secondItem="Qw0-EW-Gqe" secondAttribute="trailing" id="hfz-h6-7IC"/>
                             <constraint firstItem="cS4-BM-5jE" firstAttribute="trailing" secondItem="LCc-0b-GqK" secondAttribute="trailing" id="jgf-QQ-eO0"/>
                             <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="cS4-BM-5jE" secondAttribute="trailing" constant="25" id="jrW-GH-f1U"/>
+                            <constraint firstItem="ZdG-yb-knB" firstAttribute="trailing" secondItem="fhx-PY-MvB" secondAttribute="trailing" constant="25" id="lnL-Dq-5Nn"/>
+                            <constraint firstItem="Vse-Uz-01e" firstAttribute="leading" secondItem="ZdG-yb-knB" secondAttribute="leading" constant="26" id="m0F-0n-FsQ"/>
                             <constraint firstItem="cS4-BM-5jE" firstAttribute="top" secondItem="MX1-lp-6X6" secondAttribute="bottom" constant="16" id="xAn-8z-RSE"/>
                             <constraint firstItem="CjD-Xr-wH6" firstAttribute="top" secondItem="BMH-hQ-7SN" secondAttribute="top" constant="25" id="zr0-rN-sOX"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="searchBar" destination="cS4-BM-5jE" id="fbu-59-fz8"/>
+                        <outlet property="searchKeyword" destination="XKP-ZM-ucC" id="fr2-BO-TkB"/>
+                        <outlet property="searchTableView" destination="LCc-0b-GqK" id="QPY-af-Cpr"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mkS-B0-004" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="842" y="98"/>
+            <point key="canvasLocation" x="840" y="96.682464454976298"/>
         </scene>
     </scenes>
     <resources>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="separatorColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
@@ -8,15 +8,15 @@
 import UIKit
 
 protocol AddSecondaryPillViewControllerDelegate {
-    func modalDidFinished(selectedPill: String)
+    func didFinishModal(selectedPill: String)
 }
 
 class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UISearchBarDelegate {
 
     // MARK: @IBOutlet
-    @IBOutlet var searchBar: UISearchBar!
-    @IBOutlet var searchTableView: UITableView!
-    @IBOutlet var searchKeyword: UILabel!
+    @IBOutlet weak var searchBar: UISearchBar!
+    @IBOutlet weak var searchTableView: UITableView!
+    @IBOutlet weak var searchKeyword: UILabel!
     
     // MARK: Properties
     let cellIdentifier = "SecondaryPillTableViewCell"
@@ -54,12 +54,12 @@ class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UIT
     
     // MARK: UITableViewDelegate
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 55
+        55
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        self.delegate.modalDidFinished(selectedPill: filteredData[indexPath.row])
         dismiss(animated: true)
+        self.delegate.didFinishModal(selectedPill: filteredData[indexPath.row])
     }
     
     // MARK: UISearchBarDelegate
@@ -80,15 +80,14 @@ class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UIT
         self.searchTableView.reloadData()
     }
     
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        view.endEditing(true)
+    }
+    
     
     // MARK: Function
     func setSearchKeywordText(text: String) {
-        
-        if text.isEmpty {
-            searchKeyword.text = "없는 약 추가하기"
-        } else {
-            searchKeyword.text = "'\(text)'"
-        }
+        searchKeyword.text = text.isEmpty ? "없는 약 추가하기" : "'\(text)'"
     }
     
     // MARK: @IBAction
@@ -97,7 +96,7 @@ class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UIT
     }
     
     @IBAction func tapAddPillButton() {
-        self.delegate.modalDidFinished(selectedPill: self.searchBar.text ?? "")
+        self.delegate.didFinishModal(selectedPill: self.searchBar.text ?? "")
         
         dismiss(animated: true)
     }

--- a/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
@@ -1,0 +1,29 @@
+//
+//  AddSecondaryPillViewController.swift
+//  APillLog
+//
+//  Created by Park Sungmin on 2022/07/18.
+//
+
+import UIKit
+
+class AddSecondaryPillViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
@@ -7,23 +7,94 @@
 
 import UIKit
 
-class AddSecondaryPillViewController: UIViewController {
+protocol AddSecondaryPillViewControllerDelegate {
+    func modalDidFinished(selectedPill: String)
+}
 
+class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UISearchBarDelegate {
+
+    // MARK: @IBOutlet
+    @IBOutlet var searchBar: UISearchBar!
+    @IBOutlet var searchTableView: UITableView!
+    @IBOutlet var searchKeyword: UILabel!
+    
+    // MARK: Properties
+    let cellIdentifier = "SecondaryPillTableViewCell"
+    
+    var dummy: [String] = ["타이레놀정 500mg", "타이레놀정 160mg", "타이레놀정 80mg", "타이레놀현탁액 100ml", "부루펜시럽 80ml", "베아제정", "닥터베아제정", "훼스탈골드정", "훼스탈플러스정", "판콜에이내복액 30ml", "판피린티정", "제일쿨파스", "신신파스아렉스", "베아제정2", "닥터베아제정2", "훼스탈골드정2", "훼스탈플러스정2", "판콜에이내복액 30ml2", "판피린티정2", "제일쿨파스2", "신신파스아렉스2"]
+    var filteredData: [String]!
+    
+    
+    // MARK: LifeCycle Functions
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        filteredData = dummy
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    // MARK: UITableViewDataSource
+    // 화면 사이즈에 대응해 약 리스트를 보여주기
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        let maxCellNumber = Int((UIScreen.main.bounds.size.height - 80) / 80)
+        
+        return self.filteredData.count > maxCellNumber ? maxCellNumber : self.filteredData.count
     }
-    */
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell: SecondaryPillTableViewCell = searchTableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? SecondaryPillTableViewCell else {
+            return UITableViewCell()
+        }
+        cell.pillNameView.text = self.filteredData[indexPath.row]
+        
+        return cell
+    }
+    
+    
+    // MARK: UITableViewDelegate
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 55
+    }
+    
+    // MARK: UISearchBarDelegate
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        setSearchKeywordText(text: searchText)
+        
+        filteredData = []
+        if searchText.isEmpty {
+            filteredData = dummy
+        } else {
+            for data in dummy {
+                if data.contains(searchText.lowercased()) {
+                    filteredData.append(data)
+                }
+            }
+        }
+        
+        self.searchTableView.reloadData()
+    }
+    
+    
+    // MARK: Function
+    func setSearchKeywordText(text: String) {
+        
+        if text.isEmpty {
+            searchKeyword.text = "없는 약 추가하기"
+        } else {
+            searchKeyword.text = "'\(text)'"
+        }
+    }
+    
+    // MARK: @IBAction
+    @IBAction func tapCancleButton() {
+        dismiss(animated: true)
+    }
+    
+    @IBAction func tapAddPillButton() {
+        dismiss(animated: true)
+    }
+}
 
+class SecondaryPillTableViewCell: UITableViewCell {
+    @IBOutlet var pillNameView: UILabel!
 }

--- a/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/SecondaryPill/AddSecondaryPillViewController.swift
@@ -20,6 +20,7 @@ class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UIT
     
     // MARK: Properties
     let cellIdentifier = "SecondaryPillTableViewCell"
+    var delegate: AddSecondaryPillViewControllerDelegate! = nil
     
     var dummy: [String] = ["타이레놀정 500mg", "타이레놀정 160mg", "타이레놀정 80mg", "타이레놀현탁액 100ml", "부루펜시럽 80ml", "베아제정", "닥터베아제정", "훼스탈골드정", "훼스탈플러스정", "판콜에이내복액 30ml", "판피린티정", "제일쿨파스", "신신파스아렉스", "베아제정2", "닥터베아제정2", "훼스탈골드정2", "훼스탈플러스정2", "판콜에이내복액 30ml2", "판피린티정2", "제일쿨파스2", "신신파스아렉스2"]
     var filteredData: [String]!
@@ -54,6 +55,11 @@ class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UIT
     // MARK: UITableViewDelegate
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 55
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.delegate.modalDidFinished(selectedPill: filteredData[indexPath.row])
+        dismiss(animated: true)
     }
     
     // MARK: UISearchBarDelegate
@@ -91,6 +97,8 @@ class AddSecondaryPillViewController: UIViewController, UITableViewDelegate, UIT
     }
     
     @IBAction func tapAddPillButton() {
+        self.delegate.modalDidFinished(selectedPill: self.searchBar.text ?? "")
+        
         dismiss(animated: true)
     }
 }


### PR DESCRIPTION
###  Motivation
- 서브약 추가 뷰 구현 필요

### Key Change
- 서브약 추가 뷰 구현
- 검색 필터링 기능
- 데이터에 없는 약 이름 입력 기능
- 기기 사이즈 대응 (테이블 스크롤 불가 ... 보여줄 셀 개수 대응)
- MedicationView 구현 이후 작업을 위해 모달 뷰→부모 뷰 데이터 전달 함수 구현

### Screenshots
|약 이름 선택|없는 약 추가|기기 사이즈 대응|
|------|---|---|
|![Simulator Screen Recording - iPhone 13 Pro - 2022-07-18 at 23 38 20](https://user-images.githubusercontent.com/39216546/179540931-8860881a-a74b-490b-bfce-2e4666444945.gif)|![Simulator Screen Recording - iPhone 13 Pro - 2022-07-18 at 23 37 35](https://user-images.githubusercontent.com/39216546/179540979-168fc163-6c45-42e1-b799-379ad8976266.gif)|![Simulator Screen Shot - iPod touch (7th generation) - 2022-07-18 at 23 41 53](https://user-images.githubusercontent.com/39216546/179541002-5b541c0a-9acf-4011-ab39-20b775c344cb.png)|





