### PR TITLE
[Feat] #6 History view UI 구현

### DIFF
--- a/APillLog/APillLog.xcodeproj/project.pbxproj
+++ b/APillLog/APillLog.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		876ED1AA2882A33B00179767 /* APillLog.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 876ED1A82882A33B00179767 /* APillLog.xcdatamodeld */; };
 		876ED1AC2882A33C00179767 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 876ED1AB2882A33C00179767 /* Assets.xcassets */; };
 		876ED1AF2882A33C00179767 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 876ED1AD2882A33C00179767 /* LaunchScreen.storyboard */; };
+		87DFC9E228854E2D00CED53C /* HistoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 87DFC9E128854E2D00CED53C /* HistoryTableViewCell.xib */; };
+		87FFC2AF288535C100469728 /* HistoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FFC2AE288535C100469728 /* HistoryTableViewCell.swift */; };
 		9A273BFB2883ED1B0006427B /* Condition+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A273BF92883ED1B0006427B /* Condition+CoreDataClass.swift */; };
 		9A273BFC2883ED1B0006427B /* Condition+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A273BFA2883ED1B0006427B /* Condition+CoreDataProperties.swift */; };
 		9A7485082883D7B400E2E402 /* History+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7485062883D7B400E2E402 /* History+CoreDataClass.swift */; };
@@ -45,6 +47,8 @@
 		876ED1AB2882A33C00179767 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		876ED1AE2882A33C00179767 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		876ED1B02882A33C00179767 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		87DFC9E128854E2D00CED53C /* HistoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HistoryTableViewCell.xib; sourceTree = "<group>"; };
+		87FFC2AE288535C100469728 /* HistoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryTableViewCell.swift; sourceTree = "<group>"; };
 		9A273BF92883ED1B0006427B /* Condition+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Condition+CoreDataClass.swift"; sourceTree = "<group>"; };
 		9A273BFA2883ED1B0006427B /* Condition+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Condition+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		9A7485062883D7B400E2E402 /* History+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "History+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -188,6 +192,8 @@
 			children = (
 				A8F4F2C828847A270008EB48 /* HistoryView.storyboard */,
 				A8F4F2CE28847A510008EB48 /* HistoryViewController.swift */,
+				87FFC2AE288535C100469728 /* HistoryTableViewCell.swift */,
+				87DFC9E128854E2D00CED53C /* HistoryTableViewCell.xib */,
 			);
 			path = HistoryTab;
 			sourceTree = "<group>";
@@ -282,6 +288,7 @@
 				A8F4F2BD288477390008EB48 /* AppleSDGothicNeoB.ttf in Resources */,
 				A8F4F2BC288477390008EB48 /* AppleSDGothicNeoH.ttf in Resources */,
 				A8F4F2BF288477750008EB48 /* AppleSDGothicNeoEB.ttf in Resources */,
+				87DFC9E228854E2D00CED53C /* HistoryTableViewCell.xib in Resources */,
 				876ED1A72882A33B00179767 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -295,6 +302,7 @@
 			files = (
 				9A7485092883D7B400E2E402 /* History+CoreDataProperties.swift in Sources */,
 				A8F4F2A92884748C0008EB48 /* APillLog+Font.swift in Sources */,
+				87FFC2AF288535C100469728 /* HistoryTableViewCell.swift in Sources */,
 				A8F4F2A72884730C0008EB48 /* APillLog+Color.swift in Sources */,
 				A8F4F2CF28847A520008EB48 /* HistoryViewController.swift in Sources */,
 				A8F4F2CD28847A450008EB48 /* DiaryViewController.swift in Sources */,

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.swift
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.swift
@@ -10,17 +10,17 @@ import UIKit
 class HistoryTableViewCell: UITableViewCell {
     
     // 사용자의 정보가 담길 변수
-    @IBOutlet var createTime: UILabel!
-    @IBOutlet var pillName: UILabel!
-    @IBOutlet var sideEffect: UILabel!
-    @IBOutlet var medicinalEffect: UILabel!
-    @IBOutlet var detailContext: UILabel!
+    @IBOutlet weak var createTime: UILabel!
+    @IBOutlet weak var pillName: UILabel!
+    @IBOutlet weak var sideEffect: UILabel!
+    @IBOutlet weak var medicinalEffect: UILabel!
+    @IBOutlet weak var detailContext: UILabel!
     
     // UILabel이 담긴 StackView (ex. 약 복용 + 콘서타18mg)
-    @IBOutlet var stackViewPillName: UIStackView!
-    @IBOutlet var stackViewSideEffect: UIStackView!
-    @IBOutlet var stackViewMedicinalEffect: UIStackView!
-    @IBOutlet var stackViewDetailContext: UIStackView!
+    @IBOutlet weak var stackViewPillName: UIStackView!
+    @IBOutlet weak var stackViewSideEffect: UIStackView!
+    @IBOutlet weak var stackViewMedicinalEffect: UIStackView!
+    @IBOutlet weak var stackViewDetailContext: UIStackView!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.swift
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 class HistoryTableViewCell: UITableViewCell {
     
     // 사용자의 정보가 담길 변수
-    @IBOutlet weak var createTime: UILabel!
+    @IBOutlet weak var createdTime: UILabel!
     @IBOutlet weak var pillName: UILabel!
     @IBOutlet weak var sideEffect: UILabel!
     @IBOutlet weak var medicinalEffect: UILabel!

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.swift
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.swift
@@ -1,0 +1,30 @@
+//
+//  HistoryTableViewCell.swift
+//  APillLog
+//
+//  Created by 이지원 on 2022/07/18.
+//
+
+import UIKit
+
+class HistoryTableViewCell: UITableViewCell {
+    
+    // 사용자의 정보가 담길 변수
+    @IBOutlet var createTime: UILabel!
+    @IBOutlet var pillName: UILabel!
+    @IBOutlet var sideEffect: UILabel!
+    @IBOutlet var medicinalEffect: UILabel!
+    @IBOutlet var detailContext: UILabel!
+    
+    // UILabel이 담긴 StackView (ex. 약 복용 + 콘서타18mg)
+    @IBOutlet var stackViewPillName: UIStackView!
+    @IBOutlet var stackViewSideEffect: UIStackView!
+    @IBOutlet var stackViewMedicinalEffect: UIStackView!
+    @IBOutlet var stackViewDetailContext: UIStackView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    
+}

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
@@ -8,11 +8,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="250" id="R0G-xG-O1P" customClass="HistoryTableViewCell" customModule="APillLog" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="253" id="R0G-xG-O1P" customClass="HistoryTableViewCell" customModule="APillLog" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="253"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="R0G-xG-O1P" id="CKP-yI-lkM">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="253"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFd-rc-lwZ">
@@ -21,8 +21,8 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xME-xU-qZe">
-                        <rect key="frame" x="30" y="15" width="49" height="220"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="xME-xU-qZe">
+                        <rect key="frame" x="30" y="15" width="49" height="223"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Lao-eb-nsh">
                                 <rect key="frame" x="0.0" y="0.0" width="49" height="40.5"/>
@@ -76,7 +76,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lRz-SY-bVB">
-                                <rect key="frame" x="0.0" y="164.5" width="49" height="40.5"/>
+                                <rect key="frame" x="0.0" y="166.5" width="49" height="40.5"/>
                                 <subviews>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추가 기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DyM-xk-7fG">
                                         <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
@@ -120,7 +120,7 @@
                 <outlet property="stackViewPillName" destination="Lao-eb-nsh" id="JqH-IN-eB2"/>
                 <outlet property="stackViewSideEffect" destination="CQE-La-at0" id="pz1-H9-i5q"/>
             </connections>
-            <point key="canvasLocation" x="266.66666666666669" y="165.40178571428569"/>
+            <point key="canvasLocation" x="266.66666666666669" y="165.73660714285714"/>
         </tableViewCell>
     </objects>
 </document>

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
@@ -8,33 +8,36 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="253" id="R0G-xG-O1P" customClass="HistoryTableViewCell" customModule="APillLog" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="253"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="291" id="R0G-xG-O1P" customClass="HistoryTableViewCell" customModule="APillLog" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="291"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="R0G-xG-O1P" id="CKP-yI-lkM">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="253"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="291"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFd-rc-lwZ">
-                        <rect key="frame" x="346.5" y="15" width="42.5" height="19.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFd-rc-lwZ">
+                        <rect key="frame" x="339" y="15" width="50" height="19.5"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="50" id="P18-4z-rpI"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="xME-xU-qZe">
-                        <rect key="frame" x="30" y="15" width="49" height="223"/>
+                        <rect key="frame" x="30" y="15" width="299" height="261"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Lao-eb-nsh">
-                                <rect key="frame" x="0.0" y="0.0" width="49" height="40.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="299" height="40.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="약 복용" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFr-hW-hlR">
-                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="299" height="16"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <color key="textColor" red="0.48627450980392156" green="0.48627450980392156" blue="0.48627450980392156" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4km-14-vql">
-                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                        <rect key="frame" x="0.0" y="21" width="299" height="19.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -42,16 +45,16 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="CQE-La-at0">
-                                <rect key="frame" x="0.0" y="55.5" width="49" height="40.5"/>
+                                <rect key="frame" x="0.0" y="55.5" width="299" height="40.5"/>
                                 <subviews>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="불편 사항" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0r8-ST-m8T">
-                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="299" height="16"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <color key="textColor" red="0.48627450979999998" green="0.48627450979999998" blue="0.48627450979999998" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLH-lx-n8k">
-                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLH-lx-n8k">
+                                        <rect key="frame" x="0.0" y="21" width="299" height="19.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -59,16 +62,16 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7OP-hy-fkp">
-                                <rect key="frame" x="0.0" y="111" width="49" height="40.5"/>
+                                <rect key="frame" x="0.0" y="111" width="299" height="40.5"/>
                                 <subviews>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개선 사항" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nT6-vE-qgY">
-                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="299" height="16"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <color key="textColor" red="0.48627450979999998" green="0.48627450979999998" blue="0.48627450979999998" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k0c-Vb-PWV">
-                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k0c-Vb-PWV">
+                                        <rect key="frame" x="0.0" y="21" width="299" height="19.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -76,16 +79,16 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lRz-SY-bVB">
-                                <rect key="frame" x="0.0" y="166.5" width="49" height="40.5"/>
+                                <rect key="frame" x="0.0" y="166.5" width="299" height="40.5"/>
                                 <subviews>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추가 기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DyM-xk-7fG">
-                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="299" height="16"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <color key="textColor" red="0.48627450979999998" green="0.48627450979999998" blue="0.48627450979999998" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SqS-vB-UzE">
-                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SqS-vB-UzE">
+                                        <rect key="frame" x="0.0" y="21" width="299" height="19.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -105,6 +108,8 @@
                     <constraint firstAttribute="trailing" secondItem="XFd-rc-lwZ" secondAttribute="trailing" constant="25" id="0JJ-ZW-59m"/>
                     <constraint firstItem="xME-xU-qZe" firstAttribute="leading" secondItem="CKP-yI-lkM" secondAttribute="leading" constant="30" id="6PP-o8-rJN"/>
                     <constraint firstAttribute="bottom" secondItem="xME-xU-qZe" secondAttribute="bottom" constant="15" id="6pZ-G6-UBv"/>
+                    <constraint firstItem="xME-xU-qZe" firstAttribute="centerY" secondItem="CKP-yI-lkM" secondAttribute="centerY" id="BA7-65-kFz"/>
+                    <constraint firstItem="XFd-rc-lwZ" firstAttribute="leading" secondItem="xME-xU-qZe" secondAttribute="trailing" constant="10" id="Ks3-hY-lS9"/>
                     <constraint firstItem="XFd-rc-lwZ" firstAttribute="top" secondItem="CKP-yI-lkM" secondAttribute="top" constant="15" id="nyi-LD-2YY"/>
                     <constraint firstItem="xME-xU-qZe" firstAttribute="top" secondItem="CKP-yI-lkM" secondAttribute="top" constant="15" id="rSM-TZ-cpH"/>
                 </constraints>
@@ -120,7 +125,7 @@
                 <outlet property="stackViewPillName" destination="Lao-eb-nsh" id="JqH-IN-eB2"/>
                 <outlet property="stackViewSideEffect" destination="CQE-La-at0" id="pz1-H9-i5q"/>
             </connections>
-            <point key="canvasLocation" x="266.66666666666669" y="165.73660714285714"/>
+            <point key="canvasLocation" x="266.66666666666669" y="178.45982142857142"/>
         </tableViewCell>
     </objects>
 </document>

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="250" id="R0G-xG-O1P" customClass="HistoryTableViewCell" customModule="APillLog" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="R0G-xG-O1P" id="CKP-yI-lkM">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="250"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFd-rc-lwZ">
+                        <rect key="frame" x="346.5" y="15" width="42.5" height="19.5"/>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xME-xU-qZe">
+                        <rect key="frame" x="30" y="15" width="49" height="220"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Lao-eb-nsh">
+                                <rect key="frame" x="0.0" y="0.0" width="49" height="40.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="약 복용" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFr-hW-hlR">
+                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <color key="textColor" red="0.48627450980392156" green="0.48627450980392156" blue="0.48627450980392156" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4km-14-vql">
+                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="CQE-La-at0">
+                                <rect key="frame" x="0.0" y="55.5" width="49" height="40.5"/>
+                                <subviews>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="불편 사항" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0r8-ST-m8T">
+                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <color key="textColor" red="0.48627450979999998" green="0.48627450979999998" blue="0.48627450979999998" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLH-lx-n8k">
+                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7OP-hy-fkp">
+                                <rect key="frame" x="0.0" y="111" width="49" height="40.5"/>
+                                <subviews>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개선 사항" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nT6-vE-qgY">
+                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <color key="textColor" red="0.48627450979999998" green="0.48627450979999998" blue="0.48627450979999998" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k0c-Vb-PWV">
+                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lRz-SY-bVB">
+                                <rect key="frame" x="0.0" y="164.5" width="49" height="40.5"/>
+                                <subviews>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="추가 기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DyM-xk-7fG">
+                                        <rect key="frame" x="0.0" y="0.0" width="49" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <color key="textColor" red="0.48627450979999998" green="0.48627450979999998" blue="0.48627450979999998" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SqS-vB-UzE">
+                                        <rect key="frame" x="0.0" y="21" width="49" height="19.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="lRz-SY-bVB" firstAttribute="top" secondItem="7OP-hy-fkp" secondAttribute="bottom" constant="15" id="C7b-C3-TdB"/>
+                            <constraint firstItem="CQE-La-at0" firstAttribute="top" secondItem="Lao-eb-nsh" secondAttribute="bottom" constant="15" id="VBQ-VX-goK"/>
+                            <constraint firstAttribute="bottom" secondItem="lRz-SY-bVB" secondAttribute="bottom" constant="15" id="gt4-x3-HM7"/>
+                            <constraint firstItem="7OP-hy-fkp" firstAttribute="top" secondItem="CQE-La-at0" secondAttribute="bottom" constant="15" id="zqP-e4-11f"/>
+                        </constraints>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="XFd-rc-lwZ" secondAttribute="trailing" constant="25" id="0JJ-ZW-59m"/>
+                    <constraint firstItem="xME-xU-qZe" firstAttribute="leading" secondItem="CKP-yI-lkM" secondAttribute="leading" constant="30" id="6PP-o8-rJN"/>
+                    <constraint firstAttribute="bottom" secondItem="xME-xU-qZe" secondAttribute="bottom" constant="15" id="6pZ-G6-UBv"/>
+                    <constraint firstItem="XFd-rc-lwZ" firstAttribute="top" secondItem="CKP-yI-lkM" secondAttribute="top" constant="15" id="nyi-LD-2YY"/>
+                    <constraint firstItem="xME-xU-qZe" firstAttribute="top" secondItem="CKP-yI-lkM" secondAttribute="top" constant="15" id="rSM-TZ-cpH"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="createTime" destination="XFd-rc-lwZ" id="eHi-NX-9EV"/>
+                <outlet property="detailContext" destination="SqS-vB-UzE" id="Ffs-RL-lEY"/>
+                <outlet property="medicinalEffect" destination="k0c-Vb-PWV" id="gIQ-Iw-60b"/>
+                <outlet property="pillName" destination="4km-14-vql" id="Q3i-zI-gRs"/>
+                <outlet property="sideEffect" destination="rLH-lx-n8k" id="JKb-Qy-Pmy"/>
+                <outlet property="stackViewDetailContext" destination="lRz-SY-bVB" id="bxC-rH-MO7"/>
+                <outlet property="stackViewMedicinalEffect" destination="7OP-hy-fkp" id="HUi-JN-eCp"/>
+                <outlet property="stackViewPillName" destination="Lao-eb-nsh" id="JqH-IN-eB2"/>
+                <outlet property="stackViewSideEffect" destination="CQE-La-at0" id="pz1-H9-i5q"/>
+            </connections>
+            <point key="canvasLocation" x="266.66666666666669" y="165.40178571428569"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
+++ b/APillLog/APillLog/View/HistoryTab/HistoryTableViewCell.xib
@@ -115,7 +115,7 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="createTime" destination="XFd-rc-lwZ" id="eHi-NX-9EV"/>
+                <outlet property="createdTime" destination="XFd-rc-lwZ" id="eHi-NX-9EV"/>
                 <outlet property="detailContext" destination="SqS-vB-UzE" id="Ffs-RL-lEY"/>
                 <outlet property="medicinalEffect" destination="k0c-Vb-PWV" id="gIQ-Iw-60b"/>
                 <outlet property="pillName" destination="4km-14-vql" id="Q3i-zI-gRs"/>

--- a/APillLog/APillLog/View/HistoryTab/HistoryView.storyboard
+++ b/APillLog/APillLog/View/HistoryTab/HistoryView.storyboard
@@ -4,45 +4,52 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--히스토리-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="HistoryViewController" id="Y6W-OH-hqX" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HistoryViewController" id="Y6W-OH-hqX" customClass="HistoryViewController" customModule="APillLog" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="History View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aDe-J5-vSx">
-                                <rect key="frame" x="159" y="437.5" width="96" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="7월 18일 월요일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ib6-nq-aD6">
+                                <rect key="frame" x="151.5" y="69" width="111" height="21"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="gm3-eL-WjG">
+                                <rect key="frame" x="0.0" y="115" width="414" height="698"/>
+                                <color key="backgroundColor" red="0.96862745100000003" green="0.96862745100000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
+                            </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="aDe-J5-vSx" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" id="1Nm-f2-nsv"/>
-                            <constraint firstItem="aDe-J5-vSx" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="wQS-VX-Gyc"/>
+                            <constraint firstItem="gm3-eL-WjG" firstAttribute="top" secondItem="ib6-nq-aD6" secondAttribute="bottom" constant="25" id="15F-hZ-47T"/>
+                            <constraint firstItem="ib6-nq-aD6" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="B8C-UT-txm"/>
+                            <constraint firstItem="gm3-eL-WjG" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="G8o-0r-ORn"/>
+                            <constraint firstItem="gm3-eL-WjG" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="ZXL-Kd-Knq"/>
+                            <constraint firstItem="gm3-eL-WjG" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="hFh-ao-4nj"/>
+                            <constraint firstItem="ib6-nq-aD6" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="25" id="zhw-Fh-mq0"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="히스토리" image="chart.bar" catalog="system" selectedImage="chart.bar.fill" id="A2V-tg-VUy"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="tableView" destination="gm3-eL-WjG" id="E3C-ZI-OgD"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="93" y="96"/>
+            <point key="canvasLocation" x="92.753623188405811" y="95.758928571428569"/>
         </scene>
     </scenes>
     <resources>
         <image name="chart.bar" catalog="system" width="128" height="90"/>
         <image name="chart.bar.fill" catalog="system" width="128" height="92"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/APillLog/APillLog/View/HistoryTab/HistoryViewController.swift
+++ b/APillLog/APillLog/View/HistoryTab/HistoryViewController.swift
@@ -7,23 +7,63 @@
 
 import UIKit
 
-class HistoryViewController: UIViewController {
+class HistoryViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
+    @IBOutlet var tableView: UITableView!
+    
+    let dummyData = getDummyData()
+    let category = ["약 복용", "불편 사항", "개선 사항", "추가 기록"]
+    let pillText = ["두통", "콘서타 18mg", "인데놀 1정", "눈물 촉촉"]
+    let timeText = ["7:00", "8:00", "12:00", "14:00"]
+    
+    // MARK: LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        let nib = UINib(nibName: "HistoryTableViewCell", bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: "HistoryTableViewCell")
+        tableView.delegate = self
+        tableView.dataSource = self
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: TableView Funcs
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        dummyData.count
     }
-    */
+    
+    // TODO: CoreData 값으로 변경
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "HistoryTableViewCell", for: indexPath) as! HistoryTableViewCell
+        
+        cell.createTime.text = dummyData[indexPath.row].createTime
+        cell.pillName.text = dummyData[indexPath.row].pillName?.joined(separator: "\n")
+        cell.sideEffect.text = dummyData[indexPath.row].conditionContext?[0]
+        cell.medicinalEffect.text = dummyData[indexPath.row].conditionContext?[1]
+        cell.detailContext.text = dummyData[indexPath.row].conditionContext?[2]
+        
+        if cell.pillName.text == nil { cell.stackViewPillName.isHidden = true }
+        if cell.sideEffect.text == nil { cell.stackViewSideEffect.isHidden = true }
+        if cell.medicinalEffect.text == nil { cell.stackViewMedicinalEffect.isHidden = true }
+        if cell.detailContext.text == nil { cell.stackViewDetailContext.isHidden = true }
+        
+        return cell
+    }
+}
 
+
+// MARK: Test를 위한 코드
+struct history {
+    var pillName: [String]?
+    var isMainPill: String?
+    var conditionContext: [String?]?
+    var createTime: String
+}
+
+func getDummyData() -> [history] {
+    [
+        history(pillName: nil, isMainPill: nil, conditionContext: ["두통", nil, nil], createTime: "07:00"),
+        history(pillName: ["콘서타 18mg"], isMainPill: "main", conditionContext: nil, createTime: "08:00"),
+        history(pillName: ["콘서타 18mg","인데놀 1정", "콘서타 18mg","인데놀 1정"], isMainPill: "main", conditionContext: nil, createTime: "11:00"),
+        history(pillName: nil, isMainPill: nil, conditionContext: ["두근거림", "눈물촉촉", "아침에 일어났을 때 두통이 심했어요"], createTime: "15:00")
+    ]
 }

--- a/APillLog/APillLog/View/HistoryTab/HistoryViewController.swift
+++ b/APillLog/APillLog/View/HistoryTab/HistoryViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class HistoryViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
-    @IBOutlet var tableView: UITableView!
+    @IBOutlet weak var tableView: UITableView!
     
     let dummyData = getDummyData()
     let category = ["약 복용", "불편 사항", "개선 사항", "추가 기록"]

--- a/APillLog/APillLog/View/HistoryTab/HistoryViewController.swift
+++ b/APillLog/APillLog/View/HistoryTab/HistoryViewController.swift
@@ -7,24 +7,24 @@
 
 import UIKit
 
-class HistoryViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-
+class HistoryViewController: UIViewController {
+    
     @IBOutlet weak var tableView: UITableView!
     
-    let dummyData = getDummyData()
-    let category = ["약 복용", "불편 사항", "개선 사항", "추가 기록"]
-    let pillText = ["두통", "콘서타 18mg", "인데놀 1정", "눈물 촉촉"]
-    let timeText = ["7:00", "8:00", "12:00", "14:00"]
+    let dummyData = fetchDummyData()
     
     // MARK: LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let nib = UINib(nibName: "HistoryTableViewCell", bundle: nil)
-        tableView.register(nib, forCellReuseIdentifier: "HistoryTableViewCell")
+        registerNib()
         tableView.delegate = self
         tableView.dataSource = self
     }
+}
+
+
+// MARK: Extension
+extension HistoryViewController: UITableViewDataSource, UITableViewDelegate {
     
     // MARK: TableView Funcs
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -35,7 +35,7 @@ class HistoryViewController: UIViewController, UITableViewDelegate, UITableViewD
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "HistoryTableViewCell", for: indexPath) as! HistoryTableViewCell
         
-        cell.createTime.text = dummyData[indexPath.row].createTime
+        cell.createdTime.text = dummyData[indexPath.row].createdTime
         cell.pillName.text = dummyData[indexPath.row].pillName?.joined(separator: "\n")
         cell.sideEffect.text = dummyData[indexPath.row].conditionContext?[0]
         cell.medicinalEffect.text = dummyData[indexPath.row].conditionContext?[1]
@@ -48,6 +48,11 @@ class HistoryViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         return cell
     }
+    
+    private func registerNib() {
+        let nib = UINib(nibName: "HistoryTableViewCell", bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: "HistoryTableViewCell")
+    }
 }
 
 
@@ -56,14 +61,14 @@ struct history {
     var pillName: [String]?
     var isMainPill: String?
     var conditionContext: [String?]?
-    var createTime: String
+    var createdTime: String
 }
 
-func getDummyData() -> [history] {
+private func fetchDummyData() -> [history] {
     [
-        history(pillName: nil, isMainPill: nil, conditionContext: ["두통", nil, nil], createTime: "07:00"),
-        history(pillName: ["콘서타 18mg"], isMainPill: "main", conditionContext: nil, createTime: "08:00"),
-        history(pillName: ["콘서타 18mg","인데놀 1정", "콘서타 18mg","인데놀 1정"], isMainPill: "main", conditionContext: nil, createTime: "11:00"),
-        history(pillName: nil, isMainPill: nil, conditionContext: ["두근거림", "눈물촉촉", "아침에 일어났을 때 두통이 심했어요"], createTime: "15:00")
+        history(pillName: nil, isMainPill: nil, conditionContext: ["두통", nil, nil], createdTime: "07:00"),
+        history(pillName: ["콘서타 18mg"], isMainPill: "main", conditionContext: nil, createdTime: "08:00"),
+        history(pillName: ["콘서타 18mg","인데놀 1정", "콘서타 18mg","인데놀 1정"], isMainPill: "main", conditionContext: nil, createdTime: "11:00"),
+        history(pillName: nil, isMainPill: nil, conditionContext: ["두근거림", "눈물촉촉", "아침에 일어났을 때 두통이 심했어요"], createdTime: "15:00")
     ]
 }


### PR DESCRIPTION
### Todo
- [ ] coredata와 연동하기
- [ ] calendar 구현 및 연결하기

---

### Screenshot

|prototype|iPhone13|iPhoneSE|
|---|---|---|
| <img src = "https://user-images.githubusercontent.com/68676844/179776038-ba02375e-85fc-4afc-9e11-604c7acf82cb.png" width = 250> | <img src = "https://user-images.githubusercontent.com/68676844/179776083-209779c2-9198-47b1-9d17-72211d222032.png" width = 250 > | <img src = "https://user-images.githubusercontent.com/68676844/179776097-216114a8-1334-40d9-ae7e-91d0376e3bed.png" width = 250> |


### reference
- [특정 콘텐츠가 없어질 때, padding 값이 남아있는 문제 해결](https://g-y-e-o-m.tistory.com/135)
- [Table View의 Background Color 변경](https://stackoverflow.com/questions/24743184/uitableview-set-background-color)
- [Table Cell Custom](https://blog.hyunsub.kim/iOS/How-to-Create-Paging-Table-View/)
- [awakefromNib](https://memohg.tistory.com/58)
