### PR TITLE
[Feat]  MedicationView, ManageDosingView 피드백 반영 레이아웃 및 기능 수정

### DIFF
--- a/APillLog/APillLog/View/MedicationTab/ManageDosingView/ManageDosingView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/ManageDosingView/ManageDosingView.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Gni-Eq-fJ0">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Gni-Eq-fJ0">
                                 <rect key="frame" x="5" y="139" width="380" height="651"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -64,7 +64,7 @@
                                                                         </subviews>
                                                                     </stackView>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="EAi-Vv-PBW">
-                                                                        <rect key="frame" x="304.66666666666669" y="31.999999999999989" width="20.333333333333314" height="16.666666666666668"/>
+                                                                        <rect key="frame" x="304.66666666666669" y="31.999999999999993" width="20.333333333333314" height="16.66666666666665"/>
                                                                         <color key="tintColor" name="ABlack"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" secondItem="EAi-Vv-PBW" secondAttribute="height" id="sF6-AM-W8V"/>
@@ -159,22 +159,22 @@
                                                                 </connections>
                                                             </tableView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="i2M-Hw-72j">
-                                                                <rect key="frame" x="239" y="40" width="81" height="20.333333333333329"/>
+                                                                <rect key="frame" x="253.66666666666671" y="40" width="66.333333333333343" height="20.333333333333329"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="복용 관리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cVz-VI-Kla">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="63.333333333333336" height="20.333333333333332"/>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="약 등록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cVz-VI-Kla">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="48.666666666666664" height="20.333333333333332"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="tUW-8y-ziC">
-                                                                        <rect key="frame" x="68.333333333333314" y="2" width="12.666666666666671" height="16.666666666666664"/>
+                                                                        <rect key="frame" x="53.666666666666629" y="2" width="12.666666666666671" height="16.666666666666664"/>
                                                                         <color key="tintColor" name="ABlack"/>
                                                                     </imageView>
                                                                 </subviews>
                                                             </stackView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d1n-kx-B9D">
-                                                                <rect key="frame" x="239.33333333333329" y="43" width="80.666666666666657" height="14"/>
+                                                                <rect key="frame" x="254" y="43" width="66" height="14"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <buttonConfiguration key="configuration" style="plain" title=""/>
                                                                 <connections>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -354,6 +354,7 @@
                         <outlet property="secondaryPillField" destination="PMK-9x-uNM" id="7Mt-zM-m1u"/>
                         <outlet property="secondaryPillFieldHeight" destination="5Pw-3g-7Bh" id="NQ8-mM-Fzq"/>
                         <outlet property="secondaryPillModalButton" destination="168-Nr-JJL" id="31V-cm-Osa"/>
+                        <outlet property="secondaryPillModalButtonImage" destination="Ola-aW-XUd" id="ZZQ-RC-9qa"/>
                         <outlet property="secondaryPillModalButtonLabel" destination="zWz-GB-xdO" id="bBj-ca-qCX"/>
                         <outlet property="secondaryPillTableView" destination="RId-yl-pLj" id="AJA-kj-32D"/>
                         <outlet property="secondaryPillTableViewHeight" destination="lPD-QO-HsM" id="7Ld-bK-jKD"/>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -64,7 +64,7 @@
                                                                         </subviews>
                                                                     </stackView>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="EAi-Vv-PBW">
-                                                                        <rect key="frame" x="304.66666666666669" y="31.999999999999993" width="20.333333333333314" height="16.66666666666665"/>
+                                                                        <rect key="frame" x="304.66666666666669" y="31.999999999999989" width="20.333333333333314" height="16.666666666666668"/>
                                                                         <color key="tintColor" name="ABlack"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" secondItem="EAi-Vv-PBW" secondAttribute="height" id="sF6-AM-W8V"/>
@@ -348,6 +348,7 @@
                         <outlet property="primaryPillTableView" destination="N6s-gf-qSi" id="JwQ-eh-8wK"/>
                         <outlet property="primaryPillTableViewHeight" destination="agQ-qx-kS1" id="ceM-Nr-wCW"/>
                         <outlet property="primaryPillViewLinkButton" destination="d1n-kx-B9D" id="eMH-xj-lJg"/>
+                        <outlet property="primaryPillViewLinkImage" destination="tUW-8y-ziC" id="bs3-66-h37"/>
                         <outlet property="primaryPillViewLinkLabel" destination="cVz-VI-Kla" id="Rlw-Mr-822"/>
                         <outlet property="primaryPillViewTitle" destination="qR7-9z-koG" id="cVI-fP-rR3"/>
                         <outlet property="secondaryPillField" destination="PMK-9x-uNM" id="7Mt-zM-m1u"/>
@@ -358,6 +359,7 @@
                         <outlet property="secondaryPillTableViewHeight" destination="lPD-QO-HsM" id="7Ld-bK-jKD"/>
                         <outlet property="symptomButton" destination="tZT-C6-653" id="DgG-lH-SAn"/>
                         <outlet property="symptomButtonBackgroundView" destination="8Zb-1n-zaM" id="U2a-1w-CH5"/>
+                        <outlet property="symptomButtonStack" destination="v9O-Gs-4Cx" id="nC9-kf-JFr"/>
                         <outlet property="takingAllPrimaryPillsButton" destination="njF-YA-P8j" id="gJG-uX-bYX"/>
                         <outlet property="timeSegmentedControl" destination="8wI-wB-lPe" id="7Hs-Tb-Hfu"/>
                     </connections>

--- a/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/MedicationView.storyboard
@@ -349,6 +349,7 @@
                         <outlet property="primaryPillTableViewHeight" destination="agQ-qx-kS1" id="ceM-Nr-wCW"/>
                         <outlet property="primaryPillViewLinkButton" destination="d1n-kx-B9D" id="eMH-xj-lJg"/>
                         <outlet property="primaryPillViewLinkLabel" destination="cVz-VI-Kla" id="Rlw-Mr-822"/>
+                        <outlet property="primaryPillViewTitle" destination="qR7-9z-koG" id="cVI-fP-rR3"/>
                         <outlet property="secondaryPillField" destination="PMK-9x-uNM" id="7Mt-zM-m1u"/>
                         <outlet property="secondaryPillFieldHeight" destination="5Pw-3g-7Bh" id="NQ8-mM-Fzq"/>
                         <outlet property="secondaryPillModalButton" destination="168-Nr-JJL" id="31V-cm-Osa"/>

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -27,6 +27,13 @@ class MedicationViewController: UIViewController {
     private var nowDosingTime: Int16 = 1
 
     var takingTime: Date = Date()
+    
+    let dateFormatterForCompare: DateFormatter = {
+       let df = DateFormatter()
+        df.dateFormat = "yyyy-mm-dd"
+        return df
+    }()
+    
     let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH:mm"
@@ -39,6 +46,7 @@ class MedicationViewController: UIViewController {
     @IBOutlet weak var symptomButtonBackgroundView: UIView!
 
     // Primary Pill
+    @IBOutlet weak var primaryPillViewTitle: UILabel!
     @IBOutlet weak var primaryPillField: UIView!
     @IBOutlet weak var timeSegmentedControl: UISegmentedControl!
     @IBOutlet weak var primaryPillViewLinkLabel: UILabel!
@@ -185,6 +193,14 @@ class MedicationViewController: UIViewController {
         secondaryPillList.count == 0 ? 40.0 :
         66.0 * CGFloat(secondaryPillList.count)
         secondaryPillFieldHeight.constant = CGFloat(secondaryPillTableViewHeight.constant) + 60
+    }
+    
+    private func setPrimaryTableViewTitleText(selectedDate: Date) {
+        if  dateFormatterForCompare.string(from: selectedDate) == dateFormatterForCompare.string(from: Date()) {
+            primaryPillViewTitle.text = "오늘 복용할 약이에요"
+        } else {
+            primaryPillViewTitle.text = "이전에 복용했던 약이예요"
+        }
     }
 
     // MARK: - IBActions
@@ -347,12 +363,14 @@ extension MedicationViewController: CalendarViewDelegate {
         self.date = date
         reloadPrimaryPillTableView()
         reloadSecondaryPillTableView()
+        setPrimaryTableViewTitleText(selectedDate: date)
         takingTime = date
     }
 
     func setCalendarView() {
         calendarView.delegate = self
     }
+    
     func changeDateFormat(date: Date) -> Date{
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd" // 2022-08-13

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -208,7 +208,6 @@ class MedicationViewController: UIViewController {
     
     private func checkIsToday(selectedDate: Date) {
         self.isToday = (dateFormatterForCompare.string(from: selectedDate) == dateFormatterForCompare.string(from: Date()))
-        print(dateFormatterForCompare.string(from: selectedDate))
     }
     
     private func setPrimaryTableViewTitleText() {

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -27,10 +27,11 @@ class MedicationViewController: UIViewController {
     private var nowDosingTime: Int16 = 1
 
     var takingTime: Date = Date()
+    var isToday: Bool = true
     
     let dateFormatterForCompare: DateFormatter = {
        let df = DateFormatter()
-        df.dateFormat = "yyyy-mm-dd"
+        df.dateFormat = "yyyy-MM-dd"
         return df
     }()
     
@@ -44,12 +45,14 @@ class MedicationViewController: UIViewController {
     // Symptom Button
     @IBOutlet weak var symptomButton: UIButton!
     @IBOutlet weak var symptomButtonBackgroundView: UIView!
-
+    @IBOutlet weak var symptomButtonStack: UIStackView!
+    
     // Primary Pill
     @IBOutlet weak var primaryPillViewTitle: UILabel!
     @IBOutlet weak var primaryPillField: UIView!
     @IBOutlet weak var timeSegmentedControl: UISegmentedControl!
     @IBOutlet weak var primaryPillViewLinkLabel: UILabel!
+    @IBOutlet weak var primaryPillViewLinkImage: UIImageView!
     @IBOutlet weak var primaryPillViewLinkButton: UIButton!
     @IBOutlet weak var primaryPillTableView: UITableView!
     @IBOutlet weak var primaryPillTableViewHeight: NSLayoutConstraint!
@@ -195,11 +198,36 @@ class MedicationViewController: UIViewController {
         secondaryPillFieldHeight.constant = CGFloat(secondaryPillTableViewHeight.constant) + 60
     }
     
-    private func setPrimaryTableViewTitleText(selectedDate: Date) {
-        if  dateFormatterForCompare.string(from: selectedDate) == dateFormatterForCompare.string(from: Date()) {
+    private func checkIsToday(selectedDate: Date) {
+        self.isToday = (dateFormatterForCompare.string(from: selectedDate) == dateFormatterForCompare.string(from: Date()))
+        print(dateFormatterForCompare.string(from: selectedDate))
+    }
+    
+    private func setPrimaryTableViewTitleText() {
+        if isToday {
             primaryPillViewTitle.text = "오늘 복용할 약이에요"
         } else {
             primaryPillViewTitle.text = "이전에 복용했던 약이예요"
+        }
+    }
+    
+    private func setPrimaryPillViewLinkActivation() {
+        if isToday {
+            primaryPillViewLinkButton.isEnabled = true
+            primaryPillViewLinkLabel.textColor = .AColor.black
+            primaryPillViewLinkImage.tintColor = .AColor.black
+        } else {
+            primaryPillViewLinkButton.isEnabled = false
+            primaryPillViewLinkLabel.textColor = .AColor.disable
+            primaryPillViewLinkImage.tintColor = .AColor.disable
+        }
+    }
+    
+    private func setSymptomButtonAvailable() {
+        if isToday {
+            symptomButtonStack.isHidden = false
+        } else {
+            symptomButtonStack.isHidden = true
         }
     }
 
@@ -361,9 +389,16 @@ extension MedicationViewController: TakeMedicationDelegate {
 extension MedicationViewController: CalendarViewDelegate {
     func fetchDate(date: Date) {
         self.date = date
+        
+        checkIsToday(selectedDate: date)
+        
         reloadPrimaryPillTableView()
         reloadSecondaryPillTableView()
-        setPrimaryTableViewTitleText(selectedDate: date)
+        
+        setPrimaryTableViewTitleText()
+        setPrimaryPillViewLinkActivation()
+        setSymptomButtonAvailable()
+        
         takingTime = date
     }
 

--- a/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/MedicationViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Charts
 
 class MedicationViewController: UIViewController {
 
@@ -62,6 +63,7 @@ class MedicationViewController: UIViewController {
     // Secondary Pill
     @IBOutlet weak var secondaryPillField: UIView!
     @IBOutlet weak var secondaryPillModalButtonLabel: UILabel!
+    @IBOutlet weak var secondaryPillModalButtonImage: UIImageView!
     @IBOutlet weak var secondaryPillModalButton: UIButton!
     @IBOutlet weak var secondaryPillTableView: UITableView!
     @IBOutlet weak var secondaryPillTableViewHeight: NSLayoutConstraint!
@@ -134,6 +136,9 @@ class MedicationViewController: UIViewController {
 
     private func setPrimaryPillViewStyle() {
         
+        // 버튼 UI
+        primaryPillViewLinkImage.image = UIImage(systemName: "chevron.right", withConfiguration: UIImage.SymbolConfiguration(font: NSUIFont.AFont.navigationButtonDescriptionLabel))
+        
         // Primary Pill 영역
         primaryPillField.layer.cornerRadius = 10
         primaryPillViewLinkLabel.font = UIFont.AFont.navigationButtonDescriptionLabel
@@ -149,6 +154,9 @@ class MedicationViewController: UIViewController {
     }
 
     private func setSecondaryPillViewStyle() {
+        
+        // 버튼 UI
+        secondaryPillModalButtonImage.image = UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(font: NSUIFont.AFont.navigationButtonDescriptionLabel))
         
         // Secondary Pill 영역
         secondaryPillField.layer.cornerRadius = 10


### PR DESCRIPTION
### Key Changes
- S - 복용관리 >, + 텍스트와 사이즈 맞추기

- W - “오늘 복용할 약이에요” → 날짜에 따라 "이전에 복용했던 약이에요"로 텍스트 변경
- F - 이전 날짜에서 복용관리 비활성화 (회색으로 변경)
- F - 이전 날짜에서 증상입력 비활성화 (뷰에서 사라짐)

- W - 메디케이션뷰 “복용관리” -> “약 등록”

- F - AddSideEffect 스크롤바 제거