### PR TITLE
HistoryCalendarView/CheckConditionView Sprint3 수정사항 반영

### DIFF
--- a/APillLog/APillLog.xcodeproj/project.pbxproj
+++ b/APillLog/APillLog.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		34440E6128870AE700AA3996 /* ManageDosingView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34440E6028870AE700AA3996 /* ManageDosingView.storyboard */; };
 		34440E6328870B1200AA3996 /* ManageDosingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34440E6228870B1200AA3996 /* ManageDosingViewController.swift */; };
 		34500DCE28944AE100CC96F1 /* ConnectionModelPhone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34500DCD28944AE100CC96F1 /* ConnectionModelPhone.swift */; };
+		3459C3DD289519D200C68B34 /* HistoryDetailView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3459C3DC289519D200C68B34 /* HistoryDetailView.storyboard */; };
 		34743DD8289441FB00F3A2DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 34743DD7289441FB00F3A2DC /* Assets.xcassets */; };
 		34743DDE289441FB00F3A2DC /* ApillLogWatch WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 34743DDD289441FB00F3A2DC /* ApillLogWatch WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		34743DE3289441FB00F3A2DC /* APillLogApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34743DE2289441FB00F3A2DC /* APillLogApp.swift */; };
@@ -41,7 +42,6 @@
 		34743E11289448AF00F3A2DC /* ConnectionModelWatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34743E10289448AF00F3A2DC /* ConnectionModelWatch.swift */; };
 		34743E13289448D000F3A2DC /* RecordPrimaryPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34743E12289448D000F3A2DC /* RecordPrimaryPillView.swift */; };
 		34743E15289448E000F3A2DC /* CheckConditionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34743E14289448E000F3A2DC /* CheckConditionView.swift */; };
-		3459C3DD289519D200C68B34 /* HistoryDetailView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3459C3DC289519D200C68B34 /* HistoryDetailView.storyboard */; };
 		34982C602885420F003BBBD4 /* AddSecondaryPillView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34982C5F2885420F003BBBD4 /* AddSecondaryPillView.storyboard */; };
 		34982C6228854424003BBBD4 /* AddSecondaryPillViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34982C6128854424003BBBD4 /* AddSecondaryPillViewController.swift */; };
 		34BBD0652895480600F74520 /* EmptyDosingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 34F397C62892E8B20074A03D /* EmptyDosingTableViewCell.xib */; };
@@ -71,6 +71,7 @@
 		87D759322887F172007FCDF0 /* CalendarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 87D759312887F172007FCDF0 /* CalendarView.xib */; };
 		87D759342887F180007FCDF0 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D759332887F180007FCDF0 /* CalendarView.swift */; };
 		87FFC2AF288535C100469728 /* HistoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FFC2AE288535C100469728 /* HistoryTableViewCell.swift */; };
+		8B1DBD8828A48CC7007580D7 /* ConditionChipButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1DBD8728A48CC7007580D7 /* ConditionChipButton.swift */; };
 		8B942AFF28854E6300507AC5 /* AddPrimaryPillViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B942AFE28854E6300507AC5 /* AddPrimaryPillViewController.swift */; };
 		8B942B0128854E8500507AC5 /* AddPrimaryPill.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B942B0028854E8500507AC5 /* AddPrimaryPill.storyboard */; };
 		8B942B032885557D00507AC5 /* PrimaryPillDosingCycleChipButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B942B022885557D00507AC5 /* PrimaryPillDosingCycleChipButton.swift */; };
@@ -165,6 +166,7 @@
 		34440E6028870AE700AA3996 /* ManageDosingView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ManageDosingView.storyboard; sourceTree = "<group>"; };
 		34440E6228870B1200AA3996 /* ManageDosingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDosingViewController.swift; sourceTree = "<group>"; };
 		34500DCD28944AE100CC96F1 /* ConnectionModelPhone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionModelPhone.swift; sourceTree = "<group>"; };
+		3459C3DC289519D200C68B34 /* HistoryDetailView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HistoryDetailView.storyboard; sourceTree = "<group>"; };
 		34743DD5289441FA00F3A2DC /* ApillLogWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApillLogWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		34743DD7289441FB00F3A2DC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		34743DDD289441FB00F3A2DC /* ApillLogWatch WatchKit Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "ApillLogWatch WatchKit Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -180,7 +182,6 @@
 		34743E10289448AF00F3A2DC /* ConnectionModelWatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionModelWatch.swift; sourceTree = "<group>"; };
 		34743E12289448D000F3A2DC /* RecordPrimaryPillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordPrimaryPillView.swift; sourceTree = "<group>"; };
 		34743E14289448E000F3A2DC /* CheckConditionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckConditionView.swift; sourceTree = "<group>"; };
-		3459C3DC289519D200C68B34 /* HistoryDetailView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HistoryDetailView.storyboard; sourceTree = "<group>"; };
 		34982C5F2885420F003BBBD4 /* AddSecondaryPillView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AddSecondaryPillView.storyboard; sourceTree = "<group>"; };
 		34982C6128854424003BBBD4 /* AddSecondaryPillViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSecondaryPillViewController.swift; sourceTree = "<group>"; };
 		34CE290F2889307500644E4E /* MedicationPillCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MedicationPillCell.xib; sourceTree = "<group>"; };
@@ -212,6 +213,7 @@
 		87DFC9E128854E2D00CED53C /* HistoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HistoryTableViewCell.xib; sourceTree = "<group>"; };
 		87FFC2AE288535C100469728 /* HistoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryTableViewCell.swift; sourceTree = "<group>"; };
 		8AF048CC7EF14CAA4597ACF4 /* Pods-APillLog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-APillLog.debug.xcconfig"; path = "Target Support Files/Pods-APillLog/Pods-APillLog.debug.xcconfig"; sourceTree = "<group>"; };
+		8B1DBD8728A48CC7007580D7 /* ConditionChipButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionChipButton.swift; sourceTree = "<group>"; };
 		8B942AFE28854E6300507AC5 /* AddPrimaryPillViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPrimaryPillViewController.swift; sourceTree = "<group>"; };
 		8B942B0028854E8500507AC5 /* AddPrimaryPill.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AddPrimaryPill.storyboard; sourceTree = "<group>"; };
 		8B942B022885557D00507AC5 /* PrimaryPillDosingCycleChipButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryPillDosingCycleChipButton.swift; sourceTree = "<group>"; };
@@ -303,6 +305,17 @@
 			path = WatchConnection;
 			sourceTree = "<group>";
 		};
+		3459C3DB289517E100C68B34 /* HistoryDetail */ = {
+			isa = PBXGroup;
+			children = (
+				3459C3DC289519D200C68B34 /* HistoryDetailView.storyboard */,
+				8711C43328951C7B00F7625F /* HistoryDetailViewController.swift */,
+				8711C43228951C3D00F7625F /* HistoryDetailProgressView */,
+				8711C43128951C3400F7625F /* HistoryDetailChartView */,
+			);
+			path = HistoryDetail;
+			sourceTree = "<group>";
+		};
 		34743DD6289441FA00F3A2DC /* ApillLogWatch */ = {
 			isa = PBXGroup;
 			children = (
@@ -336,17 +349,6 @@
 				34743DEF289441FC00F3A2DC /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		3459C3DB289517E100C68B34 /* HistoryDetail */ = {
-			isa = PBXGroup;
-			children = (
-				3459C3DC289519D200C68B34 /* HistoryDetailView.storyboard */,
-				8711C43328951C7B00F7625F /* HistoryDetailViewController.swift */,
-				8711C43228951C3D00F7625F /* HistoryDetailProgressView */,
-				8711C43128951C3400F7625F /* HistoryDetailChartView */,
-			);
-			path = HistoryDetail;
 			sourceTree = "<group>";
 		};
 		347E4F902892E7150043136A /* ManageDosingViewCustomCell */ = {
@@ -464,6 +466,7 @@
 			children = (
 				8BFE752528880310008748B9 /* CheckConditionView.storyboard */,
 				8BFE75272888031A008748B9 /* CheckConditionViewController.swift */,
+				8B1DBD8728A48CC7007580D7 /* ConditionChipButton.swift */,
 			);
 			path = CheckCondition;
 			sourceTree = "<group>";
@@ -947,6 +950,7 @@
 				34CE29122889308200644E4E /* MedicationPillCell.swift in Sources */,
 				34F397C72892E8B20074A03D /* EmptyDosingTableViewCell.swift in Sources */,
 				876ED1AA2882A33B00179767 /* APillLog.xcdatamodeld in Sources */,
+				8B1DBD8828A48CC7007580D7 /* ConditionChipButton.swift in Sources */,
 				34982C6228854424003BBBD4 /* AddSecondaryPillViewController.swift in Sources */,
 				A8F4F2CB28847A380008EB48 /* MedicationViewController.swift in Sources */,
 				78D8B11A2887D42500ADF830 /* DiaryWriteViewController.swift in Sources */,

--- a/APillLog/APillLog/Extentions/APillLog+Font.swift
+++ b/APillLog/APillLog/Extentions/APillLog+Font.swift
@@ -27,7 +27,7 @@ private let customFonts: [UIFont.TextStyle: UIFont] = [
     .title1: UIFont(name: "AppleSDGothicNEOB00", size: 20)!,
     .title2: UIFont(name: "AppleSDGothicNEOB00", size: 18)!,
     .title3: UIFont(name: "AppleSDGothicNEOB00", size: 17)!,
-    .headline: UIFont(name: "AppleSDGothicNEOEB00", size: 17)!,
+    .headline: UIFont(name: "AppleSDGothicNEOSB00", size: 16)!,
     .body: UIFont(name: "AppleSDGothicNeoR00", size: 16)!,
     .callout: UIFont(name: "AppleSDGothicNeoR00", size: 15)!,
     .subheadline: UIFont(name: "AppleSDGothicNeoR00", size: 15)!,
@@ -67,7 +67,6 @@ extension UIFont {
         
         static var tableViewBody: UIFont { UIFont.APillLogFont(forTextStyle: .body) }
         static var searchResult: UIFont { UIFont.APillLogFont(forTextStyle: .body) }
-        static var chipText: UIFont { UIFont.APillLogFont(forTextStyle: .body) }
         static var articleBody: UIFont { UIFont.APillLogFont(forTextStyle: .body) }
         
         static var placeholder: UIFont { UIFont.APillLogFont(forTextStyle: .caption1) }
@@ -80,6 +79,8 @@ extension UIFont {
         static var explainText: UIFont { UIFont.APillLogFont(forTextStyle: .caption2) }
         static var segmentedControl: UIFont { UIFont.APillLogFont(forTextStyle: .caption2) }
         static var caption: UIFont { UIFont.APillLogFont(forTextStyle: .caption2) }
+        
+        static var chipText: UIFont { UIFont.APillLogFont(forTextStyle: .headline) }
         
         static var historyCategory: UIFont { UIFont.APillLogFont(forTextStyle: .body)}
         

--- a/APillLog/APillLog/Extentions/APillLog+Font.swift
+++ b/APillLog/APillLog/Extentions/APillLog+Font.swift
@@ -54,6 +54,7 @@ extension UIFont {
         static var calenderText: UIFont { UIFont.APillLogFont(forTextStyle: .title1) }
         static var modalViewTitle: UIFont { UIFont.APillLogFont(forTextStyle: .title1) }
         static var halfModalViewTitle: UIFont { UIFont.APillLogFont(forTextStyle: .title1) }
+        static var checkConditionViewSectionTitle: UIFont { UIFont.APillLogFont(forTextStyle: .title1) }
         
         static var navigationTitle: UIFont { UIFont.APillLogFont(forTextStyle: .title2) }
         static var datePickerText: UIFont { UIFont.APillLogFont(forTextStyle: .title2) }

--- a/APillLog/APillLog/View/FSCalendarView/FSCalendarView.storyboard
+++ b/APillLog/APillLog/View/FSCalendarView/FSCalendarView.storyboard
@@ -215,7 +215,7 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="히스토리" image="chart.bar" catalog="system" selectedImage="chart.bar" id="pK6-OH-1CH"/>
                     <navigationItem key="navigationItem" title="히스토리" id="yH2-Ad-CZ1">
-                        <barButtonItem key="rightBarButtonItem" title="리포트   " id="EE7-Kl-wep">
+                        <barButtonItem key="rightBarButtonItem" image="chart.bar.fill" catalog="system" id="EE7-Kl-wep">
                             <color key="tintColor" name="AAccent"/>
                             <connections>
                                 <action selector="tapReportButton:" destination="Y6W-OH-hqX" id="N15-za-qUe"/>
@@ -274,6 +274,7 @@
     </scenes>
     <resources>
         <image name="chart.bar" catalog="system" width="128" height="90"/>
+        <image name="chart.bar.fill" catalog="system" width="128" height="92"/>
         <image name="chevron.backward" catalog="system" width="96" height="128"/>
         <image name="chevron.right" catalog="system" width="96" height="128"/>
         <image name="circle.fill" catalog="system" width="128" height="121"/>

--- a/APillLog/APillLog/View/FSCalendarView/FSCalendarView.storyboard
+++ b/APillLog/APillLog/View/FSCalendarView/FSCalendarView.storyboard
@@ -218,7 +218,7 @@
                         <barButtonItem key="rightBarButtonItem" title="리포트   " id="EE7-Kl-wep">
                             <color key="tintColor" name="AAccent"/>
                             <connections>
-                                <segue destination="DQT-II-Bpx" kind="show" id="Iu8-hF-d7Z"/>
+                                <action selector="tapReportButton:" destination="Y6W-OH-hqX" id="N15-za-qUe"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -264,7 +264,7 @@
         <!--HistoryDetailView-->
         <scene sceneID="Hvn-8X-tOF">
             <objects>
-                <viewControllerPlaceholder storyboardName="HistoryDetailView" referencedIdentifier="HistoryDetailView" id="DQT-II-Bpx" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardIdentifier="HistoryDetailView" storyboardName="HistoryDetailView" referencedIdentifier="HistoryDetailView" id="DQT-II-Bpx" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="Fd9-SS-SVX"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MjO-Fd-z1s" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/APillLog/APillLog/View/FSCalendarView/FSCalendarViewController.swift
+++ b/APillLog/APillLog/View/FSCalendarView/FSCalendarViewController.swift
@@ -169,6 +169,11 @@ class FSCalendarViewController: UIViewController{
         scrollCurrentPage(isPrev: false)
     }
     
+    @IBAction func tapReportButton(_ sender: UIBarButtonItem) {
+        guard let historyDetailViewController: HistoryDetailViewController = self.storyboard?.instantiateViewController(withIdentifier: "HistoryDetailView") as? HistoryDetailViewController else { return }
+        
+        self.navigationController?.pushViewController(historyDetailViewController, animated: true)
+    }
     func setUpEvents() {
         calendarView.delegate = self
         calendarView.dataSource = self

--- a/APillLog/APillLog/View/FSCalendarView/FSCalendarViewController.swift
+++ b/APillLog/APillLog/View/FSCalendarView/FSCalendarViewController.swift
@@ -113,10 +113,6 @@ class FSCalendarViewController: UIViewController{
         
         self.guideLabel.font = UIFont.AFont.noHistory
         
-        
-        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.boldSystemFont(ofSize: 17)]
-        self.reportButton.setTitleTextAttributes(attributes, for: .normal)
-        
         // delegation, datasource 할당
         setUpEvents()
         

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionView.storyboard
@@ -352,11 +352,13 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="chipTitle" destination="deb-cm-JXz" id="yau-aB-dBR"/>
                         <outlet property="conditionBackgroundView" destination="K4x-Sk-9fP" id="nIr-8Y-Dgx"/>
                         <outlet property="conditionSaveButton" destination="Zsv-fg-fkq" id="V6D-h9-gQu"/>
                         <outlet property="conditionViewNavigationBar" destination="3fT-gi-xQ6" id="2xz-Nh-N9W"/>
                         <outlet property="countDetailContext" destination="vWb-tx-qCf" id="eiq-10-RSF"/>
                         <outlet property="detailContext" destination="jap-vz-MbA" id="K63-C9-Pgo"/>
+                        <outlet property="textViewTitle" destination="5Nb-8Z-L5W" id="JPL-wH-Pvv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kdX-yn-kQH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionView.storyboard
@@ -55,7 +55,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="evw-P6-EXX">
                                                                 <rect key="frame" x="0.0" y="0.0" width="285" height="33"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j4u-rq-xwl" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j4u-rq-xwl" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="0.0" width="56" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="33" id="Hur-Kx-ARu"/>
@@ -66,15 +66,15 @@
                                                                         <state key="normal" title="불면">
                                                                             <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         </state>
-                                                                        <state key="selected" title="불면"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="AHi-HN-RJ1"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2xc-19-4JJ" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2xc-19-4JJ" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="67" y="0.0" width="56" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="33" id="DZq-EY-fWM"/>
@@ -88,12 +88,13 @@
                                                                         <state key="selected" title="불안"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="edy-7K-oc3"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zap-6e-hB9" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zap-6e-hB9" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="134" y="0.0" width="56" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="33" id="a3l-Nh-VzV"/>
@@ -107,12 +108,13 @@
                                                                         <state key="selected" title="두통"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="ont-dH-Ueu"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dBe-cY-LNs" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dBe-cY-LNs" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="201" y="0.0" width="84" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="84" id="N4T-KS-hd0"/>
@@ -126,6 +128,7 @@
                                                                         <state key="selected" title="두근거림"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="TiH-4K-YSY"/>
@@ -136,7 +139,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="gM0-1X-E50">
                                                                 <rect key="frame" x="0.0" y="50" width="274" height="33"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YTm-8H-3Lm" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YTm-8H-3Lm" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="0.0" width="84" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="33" id="Pqf-OM-Z6N"/>
@@ -150,12 +153,13 @@
                                                                         <state key="selected" title="어지러움"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="IWw-DJ-D1N"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y6o-YH-v3K" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Y6o-YH-v3K" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="95" y="0.0" width="84" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="84" id="94c-Yq-R20"/>
@@ -168,12 +172,13 @@
                                                                         </state>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="nw3-cQ-4wn"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sED-9R-Myr" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sED-9R-Myr" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="190" y="0.0" width="84" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="84" id="5rX-SN-gei"/>
@@ -186,6 +191,7 @@
                                                                         </state>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="VYi-wn-ZCr"/>
@@ -196,7 +202,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="Ete-p6-2cp">
                                                                 <rect key="frame" x="0.0" y="100" width="232" height="33"/>
                                                                 <subviews>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hbe-b2-3Lb" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hbe-b2-3Lb" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="0.0" width="56" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="56" id="2vd-yM-T3q"/>
@@ -209,12 +215,13 @@
                                                                         </state>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="e6j-OC-EbS"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YYz-sU-NfE" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YYz-sU-NfE" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="67" y="0.0" width="84" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="84" id="1X2-P7-ack"/>
@@ -227,12 +234,13 @@
                                                                         </state>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="thL-w5-SIw"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XnQ-QZ-sUk" customClass="PrimaryPillDosingCycleChipButton" customModule="APillLog" customModuleProvider="target">
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XnQ-QZ-sUk" customClass="ConditionChipButton" customModule="APillLog" customModuleProvider="target">
                                                                         <rect key="frame" x="162" y="0.0" width="70" height="33"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="33" id="tbI-eo-Qs8"/>
@@ -245,6 +253,7 @@
                                                                         </state>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isInitButton" value="YES"/>
+                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isInitConditionButton" value="YES"/>
                                                                         </userDefinedRuntimeAttributes>
                                                                         <connections>
                                                                             <action selector="toggleSideEffectButtonState:" destination="jTN-oo-mAg" eventType="touchUpInside" id="saV-2X-b8K"/>

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionView.storyboard
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionView.storyboard
@@ -257,7 +257,10 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zsv-fg-fkq">
-                                                <rect key="frame" x="24" y="384.33333333333331" width="292" height="33"/>
+                                                <rect key="frame" x="24" y="384.33333333333331" width="292" height="40"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="Re4-0Z-dna"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <color key="tintColor" name="ADisable"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionViewController.swift
@@ -148,13 +148,13 @@ class CheckConditionViewController: UIViewController {
         if button.isSelected {
             button.backgroundColor = UIColor.AColor.accent
             button.setTitleColor(UIColor.AColor.white, for: .selected)
-            button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+            button.titleLabel?.font = UIFont.AFont.chipText
             button.layer.borderWidth = 1
-            button.layer.borderColor = UIColor.white.cgColor
+            button.layer.borderColor = UIColor.AColor.white.cgColor
         } else {
             button.backgroundColor = .white
             button.setTitleColor(UIColor.AColor.gray, for: .normal)
-            button.titleLabel?.font = UIFont.systemFont(ofSize: 16)
+            button.titleLabel?.font = UIFont.AFont.chipText
             button.layer.borderWidth = 1
             button.layer.borderColor = UIColor.AColor.disable.cgColor
         }

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionViewController.swift
@@ -42,6 +42,9 @@ class CheckConditionViewController: UIViewController {
     @IBOutlet weak var conditionSaveButton: UIButton!
     @IBOutlet weak var countDetailContext: UILabel!
     
+    @IBOutlet weak var textViewTitle: UILabel!
+    @IBOutlet weak var chipTitle: UILabel!
+    
     // MARK: View LifeCycle Function
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -61,6 +64,7 @@ class CheckConditionViewController: UIViewController {
         setConditionViewNavigationBarStyle()
         setConditionSaveButtonStyle()
         setBackButtonStyle()
+        setSectionTitleStyle()
     }
     
     private func setBackButtonStyle() {
@@ -73,6 +77,11 @@ class CheckConditionViewController: UIViewController {
         button.addTarget(self, action: #selector(tapBackButton), for: .touchUpInside)
         
         self.conditionViewNavigationBar.topItem?.leftBarButtonItem = UIBarButtonItem(customView: button)
+    }
+    
+    private func setSectionTitleStyle() {
+        self.textViewTitle.font = UIFont.AFont.checkConditionViewSectionTitle
+        self.chipTitle.font = UIFont.AFont.checkConditionViewSectionTitle
     }
     
     private func setDetailContextStyle() {

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionViewController.swift
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/CheckConditionViewController.swift
@@ -93,6 +93,8 @@ class CheckConditionViewController: UIViewController {
     }
     
     private func setConditionSaveButtonStyle() {
+        self.conditionSaveButton.layer.cornerRadius = 10
+        self.conditionSaveButton.titleLabel?.font = UIFont.AFont.buttonTitle
         self.conditionSaveButtonStateStyle(self.conditionSaveButton)
     }
     

--- a/APillLog/APillLog/View/MedicationTab/CheckCondition/ConditionChipButton.swift
+++ b/APillLog/APillLog/View/MedicationTab/CheckCondition/ConditionChipButton.swift
@@ -1,24 +1,22 @@
 //
-//  PrimaryPillDosingCycleChipButton.swift
+//  ConditionChipButton.swift
 //  APillLog
 //
-//  Created by 이영준 on 2022/07/18.
+//  Created by 이영준 on 2022/08/11.
 //
 
 import UIKit
- 
 
-// MARK: Button Initialization
 @IBDesignable
-class PrimaryPillDosingCycleChipButton: UIButton {
-    @IBInspectable var isInitButton: Bool = false {
+class ConditionChipButton: UIButton {
+    @IBInspectable var isInitConditionButton: Bool = false {
         didSet {
-            if isInitButton {
+            if isInitConditionButton {
                 self.setTitleColor(UIColor.AColor.gray, for: .normal)
                 self.layer.borderWidth = 1
                 self.layer.borderColor = UIColor.AColor.disable.cgColor
                 self.layer.cornerRadius = self.frame.height / 2
-                self.titleLabel?.font = UIFont.AFont.buttonText
+                self.titleLabel?.font = UIFont.AFont.chipText
             }
         }
     }

--- a/APillLog/Pods/FSCalendar/FSCalendar/FSCalendarCell.m
+++ b/APillLog/Pods/FSCalendar/FSCalendar/FSCalendarCell.m
@@ -308,9 +308,6 @@
 
 - (NSArray<UIColor *> *)colorsForEvents
 {
-    if (self.selected) {
-        return _preferredEventSelectionColors ?: @[_appearance.eventSelectionColor];
-    }
     return _preferredEventDefaultColors ?: @[_appearance.eventDefaultColor];
 }
 


### PR DESCRIPTION
### Key Change
- HistoryCalendarView 리포트 버튼 이미지로 변경
- HistoryCalendarView FSCalendar 날짜 선택시 기존 포인트 색상 유지
- CheckCondition ChipButton/SectionTitle/SaveButton AFont 적용

### 피드백 필요한 부분
- 리포트 이미지 버튼에 대한 피드백
- CheckConditionView 로 진입하는 버튼 타이틀 "부작용을 입력하세요"로 변경 필요

### 변경 사항
|변경 1|변경 2|
|---|---|
|![Simulator Screen Shot - iPhone 11 - 2022-08-12 at 17 58 16](https://user-images.githubusercontent.com/86882798/184322239-edeff020-9edf-46f7-b78d-f4c821da40d1.png)|![Simulator Screen Shot - iPhone 11 - 2022-08-12 at 17 58 28](https://user-images.githubusercontent.com/86882798/184322274-10b92371-af34-4a5f-9d3f-40a48f69afd6.png)|