### PR TITLE
캘린더 뷰 터치 영역 확대

### DIFF
--- a/APillLog/APillLog/Utility/Calendar/CalendarView.swift
+++ b/APillLog/APillLog/Utility/Calendar/CalendarView.swift
@@ -13,6 +13,7 @@ protocol CalendarViewDelegate: AnyObject {
 
 class CalendarView: UIView {
     
+    @IBOutlet weak var calendarStackView: UIStackView!
     @IBOutlet weak var selectedDate: UILabel!
     @IBOutlet weak var nextButton: UIButton!
     @IBOutlet weak var prevButton: UIButton!
@@ -65,8 +66,8 @@ class CalendarView: UIView {
         let gestureRecognize = UITapGestureRecognizer(target: self, action: #selector(clickLabel))
         
         selectedDate.text = fetchSelectedDate(date: Date())
-        selectedDate.addGestureRecognizer(gestureRecognize)
-        selectedDate.isUserInteractionEnabled = true
+        calendarStackView.isUserInteractionEnabled = true
+        calendarStackView.addGestureRecognizer(gestureRecognize)
         
         nextButtonState = false
         prevButton.tintColor = UIColor.AColor.black

--- a/APillLog/APillLog/Utility/Calendar/CalendarView.xib
+++ b/APillLog/APillLog/Utility/Calendar/CalendarView.xib
@@ -9,6 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CalendarView" customModule="APillLog" customModuleProvider="target">
             <connections>
+                <outlet property="calendarStackView" destination="41B-tG-Dn9" id="bjd-VJ-8cL"/>
                 <outlet property="nextButton" destination="spN-ch-wd0" id="ZAV-cB-oBA"/>
                 <outlet property="prevButton" destination="41g-cQ-38l" id="VLS-4e-jUK"/>
                 <outlet property="selectedDate" destination="rUE-H1-fg8" id="KJh-jQ-4ka"/>
@@ -36,24 +37,26 @@
                     </connections>
                 </button>
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="41B-tG-Dn9">
-                    <rect key="frame" x="173.5" y="34.5" width="67.5" height="18"/>
+                    <rect key="frame" x="170" y="31" width="74.5" height="25"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="calendar" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="O0r-c2-YWq">
-                            <rect key="frame" x="0.0" y="2.5" width="18" height="12.5"/>
+                            <rect key="frame" x="0.0" y="2.5" width="25" height="19.5"/>
                             <color key="tintColor" systemColor="labelColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="O0r-c2-YWq" secondAttribute="height" id="NJp-2w-ZJR"/>
-                                <constraint firstAttribute="height" constant="18" id="gIM-nO-9OE"/>
                             </constraints>
                             <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="small"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rUE-H1-fg8">
-                            <rect key="frame" x="23" y="0.0" width="44.5" height="18"/>
+                            <rect key="frame" x="30" y="0.0" width="44.5" height="25"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="25" id="xON-i0-VBB"/>
+                    </constraints>
                 </stackView>
             </subviews>
             <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
### 작업 내용
- 기존 날짜에 두었던 터치 이벤트를 캘린더 + 날짜 라벨이 담긴 Stack View에 적용하였습니다.
- 결과화면의 경우, 터치 영역이 녹화되지 않아 첨부하지 않았습니다.